### PR TITLE
Feat/prev rendering

### DIFF
--- a/R/events.R
+++ b/R/events.R
@@ -1,8 +1,9 @@
 create_events <- function() {
   list(
     # Human infection events
-    infection = individual::Event$new('infection'),
+    clinical_infection = individual::Event$new('clinical_infection'),
     asymptomatic_infection = individual::Event$new('asymptomatic_infection'),
+    infection = individual::Event$new('infection'),
 
     # Vaccination events
     rtss_vaccination = individual::Event$new('rtss_vaccination'),

--- a/R/individuals.R
+++ b/R/individuals.R
@@ -328,6 +328,7 @@ create_individuals <- function(
     ),
     events = c(
       events$infection,
+      events$clinical_infection,
       events$asymptomatic_infection,
       events$rtss_vaccination,
       events$rtss_booster,

--- a/R/infection_processes.R
+++ b/R/infection_processes.R
@@ -290,25 +290,32 @@ schedule_infections <- function(
   infections
   ) {
   parameters <- api$get_parameters()
-  scheduled_for_infection <- union(
-    api$get_scheduled(events$infection),
-    api$get_scheduled(events$asymptomatic_infection)
-  )
+  scheduled_for_infection <- api$get_scheduled(events$infection)
   to_infect <- setdiff(
     clinical_infections,
     c(scheduled_for_infection, treated)
   )
-  to_infect_asym <- setdiff(
+
+  all_new_infections <- setdiff(
     infections,
-    c(scheduled_for_infection, clinical_infections)
+    scheduled_for_infection
+  )
+
+  to_infect_asym <- setdiff(
+    all_new_infections,
+    clinical_infections
   )
 
   if(length(to_infect) > 0) {
-    api$schedule(events$infection, to_infect, parameters$de)
+    api$schedule(events$clinical_infection, to_infect, parameters$de)
   }
 
   if(length(to_infect_asym) > 0) {
     api$schedule(events$asymptomatic_infection, to_infect_asym, parameters$de)
+  }
+
+  if(length(all_new_infections) > 0) {
+    api$schedule(events$infection, all_new_infections, parameters$de)
   }
 }
 

--- a/R/infection_processes.R
+++ b/R/infection_processes.R
@@ -204,7 +204,7 @@ update_severe_disease <- function(
   ) {
   if (length(clinical_infections) > 0) {
     parameters <- api$get_parameters()
-    iva <- api$get_variable(human, variables$iva, infections)
+    iva <- api$get_variable(human, variables$iva, clinical_infections)
     theta <- severe_immunity(
       infection_age,
       iva,

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -422,8 +422,12 @@ parameterise_human_equilibrium <- function(parameters, eq) {
 #'
 #' @param parameters the parameters to modify
 #' @param EIR to work from
+#' @param limit_grace the number of mosquitos to allocate to the simulation as a
+#' proportion of total_M. e.g. 10 will allocate total_M * 10 mosquitos. High
+#' values of `limit_grace` are required for simulations with seasonality.
 #' @export
-parameterise_mosquito_equilibrium <- function(parameters, EIR) {
+parameterise_mosquito_equilibrium <- function(parameters, EIR, limit_grace=1.5) {
   parameters$total_M <- equilibrium_total_M(parameters, EIR)
+  parameters$mosquito_limit <- parameters$total_M * limit_grace
   parameters
 }

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -188,6 +188,22 @@
 #' * mda_coverage - the proportion of the target population that will be covered
 #' * smc* - as for mda*
 #'
+#' rendering:
+#' All values are in timesteps and all ranges are inclusive
+#'
+#' * prevalence_rendering_min_ages - the minimum ages for clinical prevalence
+#' outputs
+#' * prevalence_rendering_max_ages - the corresponding max ages
+#' * incidence_rendering_min_ages - the minimum ages for clinical incidence
+#' outputs
+#' * incidence_rendering_max_ages - the corresponding max ages
+#' * severe_prevalence_rendering_min_ages - the minimum ages for severe
+#' prevalence outputs
+#' * severe_prevalence_rendering_max_ages - the corresponding max ages
+#' * severe_incidence_rendering_min_ages - the minimum ages for severe incidence
+#' outputs
+#' * severe_incidence_rendering_max_ages - the corresponding max ages
+#'
 #' miscellaneous:
 #'
 #' * human_population - the number of humans to model
@@ -334,6 +350,15 @@ get_parameters <- function(overrides = list()) {
     smc_min_age = -1,
     smc_max_age = -1,
     smc_coverage = 0,
+    # rendering
+    prevalence_rendering_min_ages = 2 * 365,
+    prevalence_rendering_max_ages = 10 * 365,
+    incidence_rendering_min_ages = numeric(0),
+    incidence_rendering_max_ages = numeric(0),
+    severe_prevalence_rendering_min_ages = numeric(0),
+    severe_prevalence_rendering_max_ages = numeric(0),
+    severe_incidence_rendering_min_ages = numeric(0),
+    severe_incidence_rendering_max_ages = numeric(0),
     # misc
     human_population = 100,
     mosquito_limit   = 100 * 1000,

--- a/R/processes.R
+++ b/R/processes.R
@@ -104,7 +104,8 @@ create_processes <- function(
       individuals$human,
       states$D,
       states$A,
-      variables$birth
+      variables$birth,
+      variables$is_severe
     ),
 
     # ==================
@@ -187,10 +188,10 @@ create_processes <- function(
 #' @param events a list of events in the model
 #' @param parameters the model parameters
 create_event_based_processes <- function(individuals, states, variables, events, parameters) {
-  events$infection$add_listener(
+  events$clinical_infection$add_listener(
     individual::update_state_listener(individuals$human$name, states$D$name)
   )
-  events$infection$add_listener(
+  events$clinical_infection$add_listener(
     function(api, target) {
       if (length(target) > 0) {
         api$queue_variable_update(
@@ -224,6 +225,14 @@ create_event_based_processes <- function(individuals, states, variables, events,
         )
       }
     }
+  )
+
+  events$infection$add_listener(
+    create_incidence_renderer(
+      individuals$human,
+      variables$birth,
+      variables$is_severe
+    )
   )
 
   if (parameters$rtss == 1) {

--- a/R/render.R
+++ b/R/render.R
@@ -1,5 +1,8 @@
 epi_from_subpopulation <- function(target, age, lower, upper) {
   in_range <- which((age >= lower) & (age <= upper))
+  if (length(in_range) == 0) {
+    return(0)
+  }
   n_target <- length(intersect(target, in_range))
   n_target / length(in_range)
 }

--- a/R/render.R
+++ b/R/render.R
@@ -1,13 +1,72 @@
-create_prevelance_renderer <- function(human, D, A, birth) {
+epi_from_subpopulation <- function(target, age, lower, upper) {
+  in_range <- which((age >= lower) & (age <= upper))
+  n_target <- length(intersect(target, in_range))
+  n_target / length(in_range)
+}
+
+create_prevelance_renderer <- function(human, D, A, birth, is_severe) {
   function(api) {
-    age <- get_age(api$get_variable(human, birth), api$get_timestep())
-    in_range <- which((age > 2 * 365) & (age < 11 * 365))
-    prev <- length(
-      intersect(api$get_state(human, D), in_range)
-    ) + length(
-      intersect(api$get_state(human, A), in_range)
+    parameters <- api$get_parameters()
+    infected <- api$get_state(human, D, A)
+    severe <- intersect(
+      infected,
+      which(api$get_variable(human, is_severe) == 1)
     )
-    api$render('prev_2_10', prev)
-    api$render('n_2_10', length(in_range))
+    age <- get_age(api$get_variable(human, birth), api$get_timestep())
+    for (i in seq_along(parameters$prevalence_rendering_min_ages)) {
+      lower <- parameters$prevalence_rendering_min_ages[[i]]
+      upper <- parameters$prevalence_rendering_max_ages[[i]]
+      p <- epi_from_subpopulation(
+        infected,
+        age,
+        lower,
+        upper
+      )
+      api$render(paste0('pv_', lower, '_', upper), p)
+    }
+    for (i in seq_along(parameters$severe_prevalence_rendering_min_ages)) {
+      lower <- parameters$severe_prevalence_rendering_min_ages[[i]]
+      upper <- parameters$severe_prevalence_rendering_max_ages[[i]]
+      p <- epi_from_subpopulation(
+        severe,
+        age,
+        lower,
+        upper
+      )
+      api$render(paste0('pv_severe_', lower, '_', upper), p)
+    }
+  }
+}
+
+create_incidence_renderer <- function(human, birth, is_severe) {
+  function(api, target) {
+    parameters <- api$get_parameters()
+    age <- get_age(api$get_variable(human, birth), api$get_timestep())
+    severe <- intersect(
+      target,
+      which(api$get_variable(human, is_severe) == 1)
+    )
+    for (i in seq_along(parameters$incidence_rendering_min_ages)) {
+      lower <- parameters$incidence_rendering_min_ages[[i]]
+      upper <- parameters$incidence_rendering_max_ages[[i]]
+      p <- epi_from_subpopulation(
+        target,
+        age,
+        lower,
+        upper
+      )
+      api$render(paste0('inc_', lower, '_', upper), p)
+    }
+    for (i in seq_along(parameters$severe_incidence_rendering_min_ages)) {
+      lower <- parameters$severe_incidence_rendering_min_ages[[i]]
+      upper <- parameters$severe_incidence_rendering_max_ages[[i]]
+      p <- epi_from_subpopulation(
+        severe,
+        age,
+        lower,
+        upper
+      )
+      api$render(paste0('inc_severe_', lower, '_', upper), p)
+    }
   }
 }

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -210,6 +210,23 @@ I recommend setting these with convenience functions in \code{mda_parameters.R}
 \item smc* - as for mda*
 }
 
+rendering:
+All values are in timesteps and all ranges are inclusive
+\itemize{
+\item prevalence_rendering_min_ages - the minimum ages for clinical prevalence
+outputs
+\item prevalence_rendering_max_ages - the corresponding max ages
+\item incidence_rendering_min_ages - the minimum ages for clinical incidence
+outputs
+\item incidence_rendering_max_ages - the corresponding max ages
+\item severe_prevalence_rendering_min_ages - the minimum ages for severe
+prevalence outputs
+\item severe_prevalence_rendering_max_ages - the corresponding max ages
+\item severe_incidence_rendering_min_ages - the minimum ages for severe incidence
+outputs
+\item severe_incidence_rendering_max_ages - the corresponding max ages
+}
+
 miscellaneous:
 \itemize{
 \item human_population - the number of humans to model

--- a/man/parameterise_mosquito_equilibrium.Rd
+++ b/man/parameterise_mosquito_equilibrium.Rd
@@ -4,12 +4,16 @@
 \alias{parameterise_mosquito_equilibrium}
 \title{Parameterise total_M and carrying capacity for mosquitos from EIR}
 \usage{
-parameterise_mosquito_equilibrium(parameters, EIR)
+parameterise_mosquito_equilibrium(parameters, EIR, limit_grace = 1.5)
 }
 \arguments{
 \item{parameters}{the parameters to modify}
 
 \item{EIR}{to work from}
+
+\item{limit_grace}{the number of mosquitos to allocate to the simulation as a
+proportion of total_M. e.g. 10 will allocate total_M * 10 mosquitos. High
+values of \code{limit_grace} are required for simulations with seasonality.}
 }
 \description{
 NOTE: the inital EIR is likely to change unless the rest of the

--- a/src/human_mortality.cpp
+++ b/src/human_mortality.cpp
@@ -191,6 +191,7 @@ Rcpp::XPtr<process_t> create_mortality_process(RandomInterface* random) {
             }
 
             api.clear_schedule("infection", died);
+            api.clear_schedule("clinical_infection", died);
             api.clear_schedule("asymptomatic_infection", died);
 
             api.queue_variable_update("human", "birth", died, variable_vector_t{static_cast<double>(timestep)});

--- a/src/test-mortality.cpp
+++ b/src/test-mortality.cpp
@@ -224,6 +224,7 @@ context("Mortality process") {
                                                 died, zero));
 
         REQUIRE_CALL(api, clear_schedule("infection", died));
+        REQUIRE_CALL(api, clear_schedule("clinical_infection", died));
         REQUIRE_CALL(api, clear_schedule("asymptomatic_infection", died));
 
         auto mortality_process = create_mortality_process(&random);

--- a/tests/testthat/test-infection-integration.R
+++ b/tests/testthat/test-infection-integration.R
@@ -92,6 +92,13 @@ test_that('human infection_process works for non-severe clinical cases', {
   mockery::expect_args(
     api$schedule,
     1,
+    events$clinical_infection,
+    3,
+    12
+  )
+  mockery::expect_args(
+    api$schedule,
+    2,
     events$infection,
     3,
     12

--- a/tests/testthat/test-process-integration.R
+++ b/tests/testthat/test-process-integration.R
@@ -29,7 +29,7 @@ test_that('Infection listener updates infectivity correctly', {
 
   api <- mock_api(list(), parameters = parameters)
 
-  events$infection$listeners[[2]](api, c(2, 4))
+  events$clinical_infection$listeners[[2]](api, c(2, 4))
   mockery::expect_args(
     api$queue_variable_update,
     1,
@@ -50,7 +50,7 @@ test_that('Infection listener doesn\'t call for empty targets', {
 
   api <- mock_api(list(), parameters = parameters)
 
-  events$infection$listeners[[2]](api, numeric(0))
+  events$clinical_infection$listeners[[2]](api, numeric(0))
   mockery::expect_called(api$queue_variable_update, 0)
 })
 

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -34,6 +34,39 @@ test_that('that default rendering works', {
   )
 })
 
+test_that('that default rendering works when no one is in the age range', {
+  parameters <- get_parameters()
+  events <- create_events()
+  states <- create_states(parameters)
+  variables <- create_variables(parameters)
+  individuals <- create_individuals(states, variables, events, parameters)
+  api <- mock_api(
+    list(
+      human = list(
+        S = c(1, 2, 3, 4),
+        birth = -c(1, 11, 21, 11) * 365
+      )
+    ),
+    parameters = parameters,
+    timestep = 0
+  )
+  renderer <- create_prevelance_renderer(
+    individuals$human,
+    states$D,
+    states$A,
+    variables$birth,
+    variables$is_severe
+  )
+  renderer(api)
+
+  mockery::expect_args(
+    api$render,
+    1,
+    'pv_730_3650',
+    0
+  )
+})
+
 test_that('that severe rendering works', {
   year <- 365
   parameters <- get_parameters(list(

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,0 +1,175 @@
+test_that('that default rendering works', {
+  parameters <- get_parameters()
+  events <- create_events()
+  states <- create_states(parameters)
+  variables <- create_variables(parameters)
+  individuals <- create_individuals(states, variables, events, parameters)
+  api <- mock_api(
+    list(
+      human = list(
+        U = c(1),
+        A = c(2),
+        D = c(3),
+        S = c(4),
+        birth = -c(2, 5, 10, 11) * 365
+      )
+    ),
+    parameters = parameters,
+    timestep = 0
+  )
+  renderer <- create_prevelance_renderer(
+    individuals$human,
+    states$D,
+    states$A,
+    variables$birth,
+    variables$is_severe
+  )
+  renderer(api)
+
+  mockery::expect_args(
+    api$render,
+    1,
+    'pv_730_3650',
+    2/3
+  )
+})
+
+test_that('that severe rendering works', {
+  year <- 365
+  parameters <- get_parameters(list(
+    severe_prevalence_rendering_min_ages = c(0, 2) * year,
+    severe_prevalence_rendering_max_ages = c(5, 10) * year,
+    prevalence_rendering_min_ages = NULL,
+    prevalence_rendering_max_ages = NULL
+  ))
+  events <- create_events()
+  states <- create_states(parameters)
+  variables <- create_variables(parameters)
+  individuals <- create_individuals(states, variables, events, parameters)
+  api <- mock_api(
+    list(
+      human = list(
+        U = c(1),
+        D = c(2, 3),
+        S = c(4),
+        A = numeric(0),
+        birth = -c(2, 5, 10, 11) * 365,
+        is_severe = c(0, 1, 0, 0)
+      )
+    ),
+    parameters = parameters,
+    timestep = 0
+  )
+  renderer <- create_prevelance_renderer(
+    individuals$human,
+    states$D,
+    states$A,
+    variables$birth,
+    variables$is_severe
+  )
+  renderer(api)
+
+  mockery::expect_args(
+    api$render,
+    1,
+    'pv_severe_0_1825',
+    1/2
+  )
+
+  mockery::expect_args(
+    api$render,
+    2,
+    'pv_severe_730_3650',
+    1/3
+  )
+})
+
+test_that('that incidence rendering works', {
+  year <- 365
+  parameters <- get_parameters(list(
+    incidence_rendering_min_ages = c(0, 2) * year,
+    incidence_rendering_max_ages = c(5, 10) * year,
+    prevalence_rendering_min_ages = NULL,
+    prevalence_rendering_max_ages = NULL
+  ))
+  events <- create_events()
+  states <- create_states(parameters)
+  variables <- create_variables(parameters)
+  individuals <- create_individuals(states, variables, events, parameters)
+  api <- mock_api(
+    list(
+      human = list(
+        birth = -c(2, 5, 10, 11) * 365,
+        is_severe = c(0, 1, 0, 0)
+      )
+    ),
+    parameters = parameters,
+    timestep = 0
+  )
+  renderer <- create_incidence_renderer(
+    individuals$human,
+    variables$birth,
+    variables$is_severe
+  )
+
+  renderer(api, c(1, 2, 4))
+
+  mockery::expect_args(
+    api$render,
+    1,
+    'inc_0_1825',
+    1
+  )
+
+  mockery::expect_args(
+    api$render,
+    2,
+    'inc_730_3650',
+    2/3
+  )
+})
+
+test_that('that severe incidence rendering works', {
+  year <- 365
+  parameters <- get_parameters(list(
+    severe_incidence_rendering_min_ages = c(0, 2) * year,
+    severe_incidence_rendering_max_ages = c(5, 10) * year,
+    prevalence_rendering_min_ages = NULL,
+    prevalence_rendering_max_ages = NULL
+  ))
+  events <- create_events()
+  states <- create_states(parameters)
+  variables <- create_variables(parameters)
+  individuals <- create_individuals(states, variables, events, parameters)
+  api <- mock_api(
+    list(
+      human = list(
+        birth = -c(2, 6, 10, 11) * 365,
+        is_severe = c(0, 1, 0, 0)
+      )
+    ),
+    parameters = parameters,
+    timestep = 0
+  )
+  renderer <- create_incidence_renderer(
+    individuals$human,
+    variables$birth,
+    variables$is_severe
+  )
+
+  renderer(api, c(1, 2, 4))
+
+  mockery::expect_args(
+    api$render,
+    1,
+    'inc_severe_0_1825',
+    0
+  )
+
+  mockery::expect_args(
+    api$render,
+    2,
+    'inc_severe_730_3650',
+    1/3
+  )
+})

--- a/vignettes/MDA.Rmd
+++ b/vignettes/MDA.Rmd
@@ -55,9 +55,8 @@ simparams <- parameterise_mosquito_equilibrium(simparams, starting_EIR)
 
 # Plotting functions
 plot_prevalence <- function(output) {
-  output$prev <- output$prev_2_10 / output$n_2_10
   ggplot(output) + geom_line(
-    aes(x = timestep, y = prev, group = repetition, alpha = 1/repetitions)
+    aes(x = timestep, y = pv_730_3650, group = repetition, alpha = 1/repetitions)
   )
 }
 

--- a/vignettes/Treatment.Rmd
+++ b/vignettes/Treatment.Rmd
@@ -34,8 +34,7 @@ simparams <- get_parameters(c(
   translate_jamie(remove_unused_jamie(jamie_params)),
   list(
     human_population = human_population,
-    variety_proportions = 1,
-    vector_ode = TRUE
+    variety_proportions = 1
   )
 ))
 simparams <- set_drugs(simparams, list(AL_params, DHC_PQP_params))
@@ -73,13 +72,12 @@ Let's plot the effect of ft on PfPrev2-10:
 
 ```{r}
 df <- do.call('rbind', lapply(seq_along(outputs), function(i) {
-  df <- outputs[[i]][c('timestep', 'prev_2_10', 'n_2_10', 'repetition')]
-  df$prev <- df$prev_2_10 / df$n_2_10
+  df <- outputs[[i]][c('timestep', 'pv_730_3650', 'repetition')]
   df$ft <- fts[[i]]
   df
 }))
     
 ggplot(df) + geom_line(
-  aes(x = timestep, y = prev, group = interaction(ft, repetition), colour = ft)
+  aes(x = timestep, y = pv_730_3650, group = interaction(ft, repetition), colour = ft)
 )
 ```

--- a/vignettes/Vaccines.Rmd
+++ b/vignettes/Vaccines.Rmd
@@ -28,9 +28,9 @@ We are going to set the default parameters to run the simulation from an equilib
 
 ```{r}
 year <- 365
-sim_length <- 100 * year
+sim_length <- 30 * year
 human_population <- 1000
-starting_EIR <- 500
+starting_EIR <- 50
 repetitions <- 5
 
 jamie_params <- load_parameter_set()
@@ -45,19 +45,22 @@ simparams <- get_parameters(c(
     g0 = 0.28605,
     g = c(0.20636, -0.0740318, -0.0009293),
     h = c(0.173743, -0.0730962, -0.116019),
-    vector_ode = TRUE
+    severe_enabled = TRUE,
+    incidence_rendering_min_ages = 0,
+    incidence_rendering_max_ages = 5 * year,
+    severe_incidence_rendering_min_ages = 0,
+    severe_incidence_rendering_max_ages = 5 * year
   )
 ))
 
 simparams <- parameterise_human_equilibrium(simparams, eq)
-simparams <- parameterise_mosquito_equilibrium(simparams, starting_EIR)
+simparams <- parameterise_mosquito_equilibrium(simparams, starting_EIR, limit_grace = 10)
 
 
 # Plotting functions
 plot_prevalence <- function(output) {
-  output$prev <- output$prev_2_10 / output$n_2_10
   ggplot(output) + geom_line(
-    aes(x = timestep, y = prev, group = repetition, alpha = 1/repetitions)
+    aes(x = timestep, y = inc_0_1825, group = repetition, alpha = 1/repetitions)
   )
 }
 
@@ -91,7 +94,7 @@ month <- 30
 
 # Add RTS,S strategy
 rtssevents = data.frame(
-  timestep = c(60, 80) * year + peak - month, #vaccine efficacy kicks off a month before the peak
+  timestep = c(10, 20) * year + peak - month, #vaccine efficacy kicks off a month before the peak
   name=c("RTS,S starts", "RTS,S ends")
 )
 

--- a/vignettes/Validation.Rmd
+++ b/vignettes/Validation.Rmd
@@ -130,10 +130,7 @@ prevs <- vapply(
       function(r) {
         mean(
           tail(
-            subset(output, output$repetition == r)$prev_2_10,
-            year
-          ) / tail(
-            subset(output, output$repetition == r)$n_2_10,
+            subset(output, output$repetition == r)$pv_730_3650,
             year
           )
         )


### PR DESCRIPTION
This change allows modellers to output prevalence and/or incidence of severe and/or clinical malaria for arbitrary age ranges.

Major changes:

* create incidence/prevalence parameters
* create incidence/prevalence processes/listeners
* rename infection > clinical_infection
* add a more general `infection` event
* update mortality process to clear infection event on death

Closes #42 