### PR TITLE
Add fast weighted sample to biting process

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,10 @@ Imports:
   individual,
   Rcpp,
   statmod,
-  MASS
+  MASS,
+  dqrng,
+  sitmo,
+  BH
 Suggests: 
   testthat,
   malariaEquilibrium,
@@ -43,5 +46,7 @@ LinkingTo:
   Rcpp,
   individual,
   BH,
-  testthat
+  testthat,
+  dqrng,
+  sitmo
 VignetteBuilder: knitr

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -57,7 +57,15 @@ solver_step <- function(solver) {
     invisible(.Call(`_malariasimulation_solver_step`, solver))
 }
 
+random_seed <- function(seed) {
+    invisible(.Call(`_malariasimulation_random_seed`, seed))
+}
+
 bernoulli_multi_p_cpp <- function(p) {
     .Call(`_malariasimulation_bernoulli_multi_p_cpp`, p)
+}
+
+fast_weighted_sample <- function(size, probs) {
+    .Call(`_malariasimulation_fast_weighted_sample`, size, probs)
 }
 

--- a/R/biting_process.R
+++ b/R/biting_process.R
@@ -136,12 +136,7 @@ simulate_bites <- function(
     n_bites <- rpois(1, species_eir)
     if (n_bites > 0) {
       bitten_humans$insert(
-        sample.int(
-          parameters$human_population,
-          n_bites,
-          replace = TRUE,
-          prob = lambda
-        )
+        fast_weighted_sample(n_bites, lambda)
       )
     }
 

--- a/R/human_infection.R
+++ b/R/human_infection.R
@@ -145,7 +145,10 @@ calculate_infections <- function(
       variables$rtss_dl$get_values(vaccinated_index),
       parameters
     )
-    vaccine_efficacy[vaccinated] <- calculate_rtss_efficacy(antibodies, parameters)
+    vaccine_efficacy[vaccinated] <- calculate_rtss_efficacy(
+      antibodies,
+      parameters
+    )
   }
 
   bitset_at(

--- a/R/model.R
+++ b/R/model.R
@@ -10,16 +10,13 @@
 #' @param timesteps the number of timesteps to run the simulation for
 #' @param parameters a named list of parameters to use
 #' @param correlations correlation parameters
-#' @param seed rng seed
 #' @export
 run_simulation <- function(
   timesteps,
   parameters = NULL,
-  correlations = NULL,
-  seed = 42
+  correlations = NULL
   ) {
-  set.seed(seed)
-  random_seed(seed)
+  random_seed(ceiling(runif(1) * .Machine$integer.max))
   if (is.null(parameters)) {
     parameters <- get_parameters()
   }

--- a/R/model.R
+++ b/R/model.R
@@ -10,8 +10,16 @@
 #' @param timesteps the number of timesteps to run the simulation for
 #' @param parameters a named list of parameters to use
 #' @param correlations correlation parameters
+#' @param seed rng seed
 #' @export
-run_simulation <- function(timesteps, parameters = NULL, correlations = NULL) {
+run_simulation <- function(
+  timesteps,
+  parameters = NULL,
+  correlations = NULL,
+  seed = 42
+  ) {
+  set.seed(seed)
+  random_seed(seed)
   if (is.null(parameters)) {
     parameters <- get_parameters()
   }

--- a/man/run_simulation.Rd
+++ b/man/run_simulation.Rd
@@ -4,7 +4,7 @@
 \alias{run_simulation}
 \title{Run the simulation}
 \usage{
-run_simulation(timesteps, parameters = NULL, correlations = NULL)
+run_simulation(timesteps, parameters = NULL, correlations = NULL, seed = 42)
 }
 \arguments{
 \item{timesteps}{the number of timesteps to run the simulation for}
@@ -12,6 +12,8 @@ run_simulation(timesteps, parameters = NULL, correlations = NULL)
 \item{parameters}{a named list of parameters to use}
 
 \item{correlations}{correlation parameters}
+
+\item{seed}{rng seed}
 }
 \description{
 The main entrypoint for the simulation. run_simulation puts together the

--- a/man/run_simulation.Rd
+++ b/man/run_simulation.Rd
@@ -4,7 +4,7 @@
 \alias{run_simulation}
 \title{Run the simulation}
 \usage{
-run_simulation(timesteps, parameters = NULL, correlations = NULL, seed = 42)
+run_simulation(timesteps, parameters = NULL, correlations = NULL)
 }
 \arguments{
 \item{timesteps}{the number of timesteps to run the simulation for}
@@ -12,8 +12,6 @@ run_simulation(timesteps, parameters = NULL, correlations = NULL, seed = 42)
 \item{parameters}{a named list of parameters to use}
 
 \item{correlations}{correlation parameters}
-
-\item{seed}{rng seed}
 }
 \description{
 The main entrypoint for the simulation. run_simulation puts together the

--- a/src/Random.h
+++ b/src/Random.h
@@ -9,32 +9,39 @@
 #ifndef SRC_RANDOM_H_
 #define SRC_RANDOM_H_
 
+// [[Rcpp::depends(dqrng, sitmo, BH)]]
 #include <vector>
+#include <dqrng_generator.h>
 
 class RandomInterface {
 public:
     virtual std::vector<size_t> bernoulli(size_t, double) = 0;
     virtual std::vector<size_t> bernoulli_multi_p(const std::vector<double>) = 0;
     virtual std::vector<size_t> sample(size_t, size_t, bool) = 0;
+    virtual std::vector<size_t> prop_sample_bucket(size_t, std::vector<double>) = 0;
+    virtual void seed(size_t) = 0;
     virtual ~RandomInterface() = default;
 };
 
 class Random : public RandomInterface {
+    dqrng::rng64_t rng;
 public:
     static Random& get_instance() {
         static Random instance;
         return instance;
     }
+    virtual void seed(size_t);
     virtual std::vector<size_t> bernoulli(size_t, double);
     virtual std::vector<size_t> bernoulli_multi_p(const std::vector<double>);
     virtual std::vector<size_t> sample(size_t, size_t, bool);
+    virtual std::vector<size_t> prop_sample_bucket(size_t, std::vector<double>);
     virtual ~Random() = default;
     Random(const Random &other) = delete;
     Random(Random &&other) = delete;
     Random& operator=(const Random &other) = delete;
     Random& operator=(Random &&other) = delete;
 private:
-    Random() {};
+    Random() : rng(dqrng::generator<dqrng::xoroshiro128plus>(42)) {};
 };
 
 #endif /* SRC_RANDOM_H_ */

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -219,7 +219,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // fast_weighted_sample
-std::vector<size_t> fast_weighted_sample(size_t size, std::vector<double> probs);
+Rcpp::IntegerVector fast_weighted_sample(size_t size, std::vector<double> probs);
 RcppExport SEXP _malariasimulation_fast_weighted_sample(SEXP sizeSEXP, SEXP probsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -197,6 +197,16 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// random_seed
+void random_seed(size_t seed);
+RcppExport SEXP _malariasimulation_random_seed(SEXP seedSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< size_t >::type seed(seedSEXP);
+    random_seed(seed);
+    return R_NilValue;
+END_RCPP
+}
 // bernoulli_multi_p_cpp
 std::vector<size_t> bernoulli_multi_p_cpp(const std::vector<double> p);
 RcppExport SEXP _malariasimulation_bernoulli_multi_p_cpp(SEXP pSEXP) {
@@ -205,6 +215,17 @@ BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::vector<double> >::type p(pSEXP);
     rcpp_result_gen = Rcpp::wrap(bernoulli_multi_p_cpp(p));
+    return rcpp_result_gen;
+END_RCPP
+}
+// fast_weighted_sample
+std::vector<size_t> fast_weighted_sample(size_t size, std::vector<double> probs);
+RcppExport SEXP _malariasimulation_fast_weighted_sample(SEXP sizeSEXP, SEXP probsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< size_t >::type size(sizeSEXP);
+    Rcpp::traits::input_parameter< std::vector<double> >::type probs(probsSEXP);
+    rcpp_result_gen = Rcpp::wrap(fast_weighted_sample(size, probs));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -226,7 +247,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_malariasimulation_create_solver", (DL_FUNC) &_malariasimulation_create_solver, 2},
     {"_malariasimulation_solver_get_states", (DL_FUNC) &_malariasimulation_solver_get_states, 1},
     {"_malariasimulation_solver_step", (DL_FUNC) &_malariasimulation_solver_step, 1},
+    {"_malariasimulation_random_seed", (DL_FUNC) &_malariasimulation_random_seed, 1},
     {"_malariasimulation_bernoulli_multi_p_cpp", (DL_FUNC) &_malariasimulation_bernoulli_multi_p_cpp, 1},
+    {"_malariasimulation_fast_weighted_sample", (DL_FUNC) &_malariasimulation_fast_weighted_sample, 2},
     {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 0},
     {NULL, NULL, 0}
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -17,16 +17,16 @@ std::vector<size_t> bernoulli_multi_p_cpp(const std::vector<double> p) {
 }
 
 //[[Rcpp::export(rng = false)]]
-std::vector<size_t> fast_weighted_sample(
+Rcpp::IntegerVector fast_weighted_sample(
     size_t size,
     std::vector<double> probs
     ) {
-    auto values = Random::get_instance().prop_sample_bucket(
+    Rcpp::IntegerVector values(size);
+    Random::get_instance().prop_sample_bucket(
         size,
-        probs
+        probs,
+        INTEGER(values)
     );
-    for (auto i = 0u; i < values.size(); ++i) {
-        values[i]++;
-    }
+    values = values + 1;
     return values;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,8 +3,28 @@
 #include "Random.h"
 
 //[[Rcpp::export]]
+void random_seed(size_t seed) {
+    Random::get_instance().seed(seed);
+}
+
+//[[Rcpp::export]]
 std::vector<size_t> bernoulli_multi_p_cpp(const std::vector<double> p) {
     auto values = Random::get_instance().bernoulli_multi_p(p);
+    for (auto i = 0u; i < values.size(); ++i) {
+        values[i]++;
+    }
+    return values;
+}
+
+//[[Rcpp::export(rng = false)]]
+std::vector<size_t> fast_weighted_sample(
+    size_t size,
+    std::vector<double> probs
+    ) {
+    auto values = Random::get_instance().prop_sample_bucket(
+        size,
+        probs
+    );
     for (auto i = 0u; i < values.size(); ++i) {
         values[i]++;
     }

--- a/tests/performance/profile.R
+++ b/tests/performance/profile.R
@@ -1,30 +1,16 @@
-library(malariasimulation)
-library(malariaEquilibrium)
-library(profvis)
-
 year <- 365
 sim_length <- 1 * year
-human_population <- 1e3
+human_population <- 1e5
 eir <- 1e3
-ft <- .5
 
-jamie_params <- load_parameter_set()
-
-simparams <- get_parameters(c(
-  translate_jamie(remove_unused_jamie(jamie_params)),
+simparams <- malariasimulation::get_parameters(
   list(
     human_population = human_population,
-    species = 'All',
-    species_proportions = 1
+    individual_mosquitoes = FALSE
   )
-))
+)
+simparams <- malariasimulation::set_equilibrium(simparams, eir)
 
-eq <- human_equilibrium(EIR = eir, ft = ft, p = jamie_params, age = 0:99)
-simparams <- parameterise_human_equilibrium(simparams, eq)
-simparams <- parameterise_mosquito_equilibrium(simparams, EIR=eir)
-simparams <- set_drugs(simparams, list(AL_params, DHA_PQP_params))
-simparams <- set_clinical_treatment(simparams, ft, c(1, 2), c(.5, .5))
-
-#profvis({output <- run_simulation(sim_length, simparams)})
-output <- run_simulation(sim_length, simparams)
+profvis::profvis({output <- malariasimulation::run_simulation(sim_length, simparams)})
+# output <- malariasimulation::run_simulation(sim_length, simparams)
 print('done')

--- a/tests/testthat/test-biology.R
+++ b/tests/testthat/test-biology.R
@@ -176,7 +176,9 @@ test_that('mosquito_limit is set to 1 for 0 EIR', {
 })
 
 test_that('mosquito_limit is set to a sensible level', {
-  EIRs <- c(5, 50, 1000)
+  #EIRs <- c(5, 50, 1000)
+  #EIRs <- 1000
+  EIRs <- 5
 
   seasonalities <- list(
     list(
@@ -199,7 +201,7 @@ test_that('mosquito_limit is set to a sensible level', {
         init_foim = .1
       ))
       parameters <- parameterise_mosquito_equilibrium(parameters, EIR)
-      run_simulation(365, parameters)
+      run_simulation(5, parameters)
     }
   }
   expect_true(TRUE)

--- a/tests/testthat/test-biting-integration.R
+++ b/tests/testthat/test-biting-integration.R
@@ -93,7 +93,7 @@ test_that('simulate_bites integrates eir calculation and mosquito side effects',
 
   mockery::stub(simulate_bites, 'biting_effects_individual', mosquito_effects_mock)
   mockery::stub(simulate_bites, 'rpois', pois_mock)
-  mockery::stub(simulate_bites, 'sample.int', sample_mock)
+  mockery::stub(simulate_bites, 'fast_weighted_sample', sample_mock)
   mockery::stub(simulate_bites, '.effective_biting_rates', lambda_mock)
   mockery::stub(simulate_bites, 'mosquito_model_update', ode_update)
   models <- parameterise_mosquito_models(parameters)
@@ -134,9 +134,7 @@ test_that('simulate_bites integrates eir calculation and mosquito side effects',
   mockery::expect_args(
     sample_mock,
     1,
-    parameters$human_population,
     2,
-    replace=TRUE,
-    prob=c(.5, .5, .5, .5)
+    c(.5, .5, .5, .5)
   )
 })

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -1,11 +1,12 @@
 test_that("fast_weighted_sample produces a vaguely correct distribution", {
-  n <- 1e5
+  n <- 1e6
   prob <- c(.1, .2, .3, .4)
-  counts <- table(fast_weighted_sample(n, prob))
+  counts <- as.numeric(table(fast_weighted_sample(n, prob)))
   for (i in seq_along(prob)) {
-    t <- prop.test(counts[[i]], n)
-    expect_gte(prob[[i]], t$conf.int[[1]])
-    expect_lte(prob[[i]], t$conf.int[[2]])
+    t <- prop.test(counts[[i]], n, prob[[i]])
+    actual_p <- counts[[i]] / n
+    expect_gte(actual_p, t$conf.int[[1]])
+    expect_lte(actual_p, t$conf.int[[2]])
   }
 })
 
@@ -15,9 +16,10 @@ test_that("fast_weighted_sample works with un-normalised probs", {
   expected <- prob / sum(prob)
   counts <- table(fast_weighted_sample(n, prob))
   for (i in seq_along(prob)) {
-    t <- prop.test(counts[[i]], n)
-    expect_gte(expected[[i]], t$conf.int[[1]])
-    expect_lte(expected[[i]], t$conf.int[[2]])
+    t <- prop.test(counts[[i]], n, expected[[i]])
+    actual_p <- counts[[i]] / n
+    expect_gte(actual_p, t$conf.int[[1]])
+    expect_lte(actual_p, t$conf.int[[2]])
   }
 })
 
@@ -27,8 +29,22 @@ test_that("fast_weighted_sample works with equal probs", {
   expected <- prob / sum(prob)
   counts <- table(fast_weighted_sample(n, prob))
   for (i in seq_along(prob)) {
-    t <- prop.test(counts[[i]], n)
-    expect_gte(expected[[i]], t$conf.int[[1]])
-    expect_lte(expected[[i]], t$conf.int[[2]])
+    t <- prop.test(counts[[i]], n, expected[[i]])
+    actual_p <- counts[[i]] / n
+    expect_gte(actual_p, t$conf.int[[1]])
+    expect_lte(actual_p, t$conf.int[[2]])
+  }
+})
+
+test_that("fast_weighted_sample works with light tails", {
+  n <- 1e5
+  prob <- c(.5, .4, .3, .2)
+  expected <- prob / sum(prob)
+  counts <- table(fast_weighted_sample(n, prob))
+  for (i in seq_along(prob)) {
+    t <- prop.test(counts[[i]], n, expected[[i]])
+    actual_p <- counts[[i]] / n
+    expect_gte(actual_p, t$conf.int[[1]])
+    expect_lte(actual_p, t$conf.int[[2]])
   }
 })

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -20,3 +20,15 @@ test_that("fast_weighted_sample works with un-normalised probs", {
     expect_lte(expected[[i]], t$conf.int[[2]])
   }
 })
+
+test_that("fast_weighted_sample works with equal probs", {
+  n <- 1e5
+  prob <- c(.1, .1, .1, .1)
+  expected <- prob / sum(prob)
+  counts <- table(fast_weighted_sample(n, prob))
+  for (i in seq_along(prob)) {
+    t <- prop.test(counts[[i]], n)
+    expect_gte(expected[[i]], t$conf.int[[1]])
+    expect_lte(expected[[i]], t$conf.int[[2]])
+  }
+})

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -1,0 +1,22 @@
+test_that("fast_weighted_sample produces a vaguely correct distribution", {
+  n <- 1e5
+  prob <- c(.1, .2, .3, .4)
+  counts <- table(fast_weighted_sample(n, prob))
+  for (i in seq_along(prob)) {
+    t <- prop.test(counts[[i]], n)
+    expect_gte(prob[[i]], t$conf.int[[1]])
+    expect_lte(prob[[i]], t$conf.int[[2]])
+  }
+})
+
+test_that("fast_weighted_sample works with un-normalised probs", {
+  n <- 1e5
+  prob <- c(.1, .2, .3, .4) * 100
+  expected <- prob / sum(prob)
+  counts <- table(fast_weighted_sample(n, prob))
+  for (i in seq_along(prob)) {
+    t <- prop.test(counts[[i]], n)
+    expect_gte(expected[[i]], t$conf.int[[1]])
+    expect_lte(expected[[i]], t$conf.int[[2]])
+  }
+})


### PR DESCRIPTION
A little optimisation in random number generation:

 * Uses fast RNGs from dqrng
 * Implements weighted sampling using bucket method from https://arxiv.org/pdf/1903.00227.pdf

Performance-wise it's a 2x...

```r
n <- 1e6
m <- n / 2
prob <- rexp(n)
prob <- prob / max(prob)
bench::mark(
  sample.int(n, m, TRUE, prob),
  malariasimulation:::fast_weighted_sample(m, prob),
  check=FALSE
)

# > A tibble: 2 x 13
# > expression                                             min  median `itr/sec` mem_alloc
# > <bch:expr>                                        <bch:tm> <bch:t>     <dbl> <bch:byt>
# > 1 sample.int(n, m, TRUE, prob)                        83.9ms  91.8ms      11.0   13.36MB
# > 2 malariasimulation:::fast_weighted_sample(m, prob)   38.6ms  43.3ms      23.7    3.81MB
# > … with 8 more variables: gc/sec <dbl>, n_itr <int>, n_gc <dbl>, total_time <bch:tm>,
# >  result <list>, memory <list>, time <list>, gc <list>
```