### PR TITLE
Fix tbv bug

### DIFF
--- a/R/events.R
+++ b/R/events.R
@@ -228,31 +228,7 @@ attach_event_listeners <- function(
 
   if (parameters$tbv == 1) {
     events$tbv_vaccination$add_listener(
-      function(timestep) {
-        time_index = which(parameters$tbv_timesteps == timestep)
-        target <- which(trunc(get_age(
-          variables$birth$get_values(),
-          timestep
-        ) / 365) %in% parameters$tbv_ages)
-        to_vaccinate <- which(sample_intervention(
-          target,
-          'tbv',
-          parameters$tbv_coverages[[time_index]],
-          correlations
-        ))
-        renderer$render('n_vaccinated_tbv', length(to_vaccinate), timestep)
-        if (length(to_vaccinate) > 0) {
-          variables$tbv_vaccinated$queue_update(
-            timestep,
-            to_vaccinate
-          )
-        }
-        if (time_index < length(parameters$tbv_timesteps)) {
-          events$tbv_vaccination$schedule(
-            parameters$tbv_timesteps[[time_index + 1]] - timestep
-          )
-        }
-      }
+      create_tbv_listener(variables, events, parameters, correlations, renderer)
     )
   }
 }

--- a/R/processes.R
+++ b/R/processes.R
@@ -80,7 +80,7 @@ create_processes <- function(
       events,
       parameters,
       LaggedValue$new(
-        parameters$delay_gam + 1,
+        parameters$delay_gam + 2,
         parameters$init_foim
       ), # lagged FOIM
       init_eir # lagged EIR

--- a/tests/testthat/test-tbv.R
+++ b/tests/testthat/test-tbv.R
@@ -12,6 +12,19 @@ test_that('TBV strategy parameterisation works', {
   expect_equal(parameters$tbv_ages, c(1, 2, 3, 18))
 })
 
+test_that('TBV scheduler works on first timestep', {
+  parameters <- get_parameters()
+  parameters <- set_tbv(
+    parameters,
+    timesteps = 10,
+    coverages = 0.8,
+    ages = c(1, 2, 3, 18)
+  )
+  output <- run_simulation(10, parameters)
+  expect_equal(output$n_vaccinated_tbv[1:9], as.numeric(rep(NA, 9)))
+  expect_gt(output$n_vaccinated_tbv[[10]], 0)
+})
+
 test_that('TBV antibodies are calculated correctly', {
   tau <- 22
   rho <- .7

--- a/vignettes/Vaccines.Rmd
+++ b/vignettes/Vaccines.Rmd
@@ -37,11 +37,8 @@ simparams <- get_parameters(list(
     g0 = 0.28605,
     g = c(0.20636, -0.0740318, -0.0009293),
     h = c(0.173743, -0.0730962, -0.116019),
-    severe_enabled = TRUE,
     incidence_rendering_min_ages = 0,
-    incidence_rendering_max_ages = 18 * year,
-    severe_incidence_rendering_min_ages = 0,
-    severe_incidence_rendering_max_ages = 18 * year
+    incidence_rendering_max_ages = 18 * year
   )
 )
 
@@ -119,7 +116,7 @@ tbvevents = data.frame(
 tbvparams <- set_tbv(
   tbvparams,
   timesteps = tbvevents$timestep,
-  coverages = rep(0.8, 2),
+  coverages = rep(0.9, 2),
   ages = seq(18)
 )
 


### PR DESCRIPTION
So it turns out that the FOIM was not updating from the equilibrium value.

Closes #109 

=== longer explanation ===

We lag FOIM by delay_gam (12.5 timesteps) and use LaggedValue objects to control that. They have a fixed buffer size, which we set to 13 timesteps. Every timestep we saved a new FOIM _before_ getting the FOIM from 12.5 timesteps ago. So the LaggedValue object was deleting the oldest FOIM value and falling back on the initial FOIM for the simulation

====================

Here are some graphs with new Vaccine vignette outputs...

![tbv_infectivity](https://user-images.githubusercontent.com/2605711/119122327-50ad7280-ba26-11eb-873b-1c1b8b69d75c.png)
![foim_1](https://user-images.githubusercontent.com/2605711/119121773-b816f280-ba25-11eb-9caf-b7eb69bab43f.png)
![tbv](https://user-images.githubusercontent.com/2605711/119121652-9453ac80-ba25-11eb-8e0c-42785367fdf8.png)