### PR TITLE
Fix setting total_M with individual mosquitoes

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -493,9 +493,10 @@ parameterise_total_M <- function(parameters, total_M) {
       )
     }))
     omega <- calculate_omega(parameters, i)
+    mum <- weighted.mean(parameters$mum, parameters$species_proportions)
     max_total_M <- max_total_M + max_K * (
       1 / (
-        2 * parameters$dl * parameters$mum * (
+        2 * parameters$dl * mum * (
           1 + parameters$dpl * parameters$mup
         )
       )

--- a/tests/testthat/test-variables.R
+++ b/tests/testthat/test-variables.R
@@ -1,11 +1,11 @@
 test_that('create_variables allows empty species', {
-  params <- malariasimulation::get_parameters()
-  params <- malariasimulation::set_species(
+  params <- get_parameters()
+  params <- set_species(
     params,
     species=list(
-      malariasimulation::gamb_params,
-      malariasimulation::arab_params,
-      malariasimulation::fun_params
+      gamb_params,
+      arab_params,
+      fun_params
     ),
     proportions=c(1,0,0)
   )
@@ -14,15 +14,33 @@ test_that('create_variables allows empty species', {
 })
 
 test_that('create_variables allows multiple species', {
-  params <- malariasimulation::get_parameters()
-  params <- malariasimulation::set_species(
+  params <- get_parameters()
+  params <- set_species(
     params,
     species=list(
-      malariasimulation::gamb_params,
-      malariasimulation::arab_params
+      gamb_params,
+      arab_params
     ),
     proportions=c(.9, .1)
   )
+  variables <- create_variables(params)
+  expect_equal(
+    variables$species$get_size_of('arab'),
+    params$total_M * .1
+  )
+})
+
+test_that('create_variables allows multiple species w different total_M', {
+  params <- get_parameters()
+  params <- set_species(
+    params,
+    species=list(
+      gamb_params,
+      arab_params
+    ),
+    proportions=c(.9, .1)
+  )
+  params <- parameterise_total_M(params, 1000)
   variables <- create_variables(params)
   expect_equal(
     variables$species$get_size_of('arab'),


### PR DESCRIPTION
Related to #116

The following test case would not work:

```r
  params <- get_parameters()
  params <- set_species(
    params,
    species=list(
      gamb_params,
      arab_params
    ),
    proportions=c(.9, .1)
  )
  params <- parameterise_total_M(params, 1000)
  run_simulation(params, 365)
```

Because paramterise_total_M would incorrectly set a mosquito_limit for each species instead of for all.