### PR TITLE
Bug/prophylaxis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Suggests:
   cowplot,
   ggplot2,
   covr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 LinkingTo:
   Rcpp,

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -346,8 +346,8 @@ get_parameters <- function(overrides = list()) {
     # treatment
     drug_efficacy          = numeric(0),
     drug_rel_c             = numeric(0),
-    drug_prophilaxis_shape = numeric(0),
-    drug_prophilaxis_scale = numeric(0),
+    drug_prophylaxis_shape = numeric(0),
+    drug_prophylaxis_scale = numeric(0),
     clinical_treatment_drugs     = list(),
     clinical_treatment_timesteps = list(),
     clinical_treatment_coverages = list(),


### PR DESCRIPTION
- changing spelling of 'prophylaxis' shape and scale parameters in parameters.R
- past misspelling created two versions of each parameter, but 'prophilaxis' named parameters were empty
- simplifying to one to reduce confusion