### PR TITLE
Bug/immunity incidence

### DIFF
--- a/R/human_infection.R
+++ b/R/human_infection.R
@@ -376,6 +376,8 @@ boost_immunity <- function(
 
 # Implemented from Winskill 2017 - Supplementary Information page 4
 clinical_immunity <- function(acquired_immunity, maternal_immunity, parameters) {
+  acquired_immunity[acquired_immunity > 0] <- acquired_immunity[acquired_immunity > 0] + 0.5
+  
   parameters$phi0 * (
     parameters$phi1 +
       (1 - parameters$phi1) /
@@ -389,6 +391,8 @@ clinical_immunity <- function(acquired_immunity, maternal_immunity, parameters) 
 
 # Implemented from Winskill 2017 - Supplementary Information page 5
 severe_immunity <- function(age, acquired_immunity, maternal_immunity, parameters) {
+  acquired_immunity[acquired_immunity > 0] <- acquired_immunity[acquired_immunity > 0] + 0.5
+  
   fv <- 1 - (1 - parameters$fv0) / (
     1 + (age / parameters$av) ** parameters$gammav
   )
@@ -421,6 +425,8 @@ asymptomatic_infectivity <- function(age, immunity, parameters) {
 
 # Implemented from Winskill 2017 - Supplementary Information page 4
 blood_immunity <- function(ib, parameters) {
+  ib[ib > 0] <- ib[ib > 0] + 0.5
+  
   parameters$b0 * (
     parameters$b1 +
       (1 - parameters$b1) /

--- a/R/human_infection.R
+++ b/R/human_infection.R
@@ -222,10 +222,11 @@ update_severe_disease <- function(
   if (infections$size() > 0) {
     age <- get_age(variables$birth$get_values(infections), timestep)
     iva <- variables$iva$get_values(infections)
+    ivm <- variables$ivm$get_values(infections)
     theta <- severe_immunity(
       age,
       iva,
-      variables$ivm$get_values(infections),
+      ivm,
       parameters
     )
     develop_severe <- bernoulli_multi_p(theta)

--- a/tests/testthat/test-infection.R
+++ b/tests/testthat/test-infection.R
@@ -12,7 +12,7 @@ test_that('blood_immunity returns correct values', {
       ib,
       parameters
     ),
-    c(.590, .590, .578),
+    c(.5900, .5898, .5771),
     tolerance=1e-3
   )
 })
@@ -28,8 +28,8 @@ test_that('clinical immunity returns correct values', {
   )
   expect_equal(
     clinical_immunity(acquired_immunity, maternal_immunity, parameters),
-    c(.0749, .0748, .0593),
-    tolerance=1e-4
+    c(.07491, .07458, .05781),
+    tolerance=1e-5
   )
 })
 
@@ -48,8 +48,8 @@ test_that('severe immunity returns correct values', {
   )
   expect_equal(
     severe_immunity(age, acquired_immunity, maternal_immunity, parameters),
-    c(0.0675, 0.0593, 0.0132),
-    tolerance=1e-4
+    c(0.06752, 0.05101, 0.01165),
+    tolerance=1e-5
   )
 })
 


### PR DESCRIPTION
A small adjustment to the estimation of immunity blood-stage, clinical and severe disease to align incidence and severe incidence estimates.

Immunity values >0 and now evaluated +0.5. This is likely to align with the mid-point of the range that would have been used for the initial fitting.

Note, this does not apply to maternally-aquired immunity.

Adjustments also made to immunity function testing. Although changes were not picked up by some of those tests due to the specified tolerances not being accurate enough. @giovannic  I upped the tolereance by an order of magnitude but we might want to push this further given how sensitive the modelled incidence is to these values?