### PR TITLE
Set default rate for rendering of state transitions in output

### DIFF
--- a/R/disease_progression.R
+++ b/R/disease_progression.R
@@ -26,6 +26,7 @@ create_progression_process <- function(event, state, from_state, rate) {
 }
 
 create_rate_listener <- function(from_state, to_state, renderer) {
+  renderer$set_default(paste0('rate_', from_state, '_', to_state), 0)
   function(timestep, target) {
     renderer$render(
       paste0('rate_', from_state, '_', to_state),


### PR DESCRIPTION
Adds defualt values to rendering of state transitions in `create_rate_listener()`. 
I've changed the suggest default from NA to 0 as I think that makes more sense?

fixes #168 