### PR TITLE
modifying mixing matrix warnings

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -151,7 +151,7 @@ run_metapop_simulation <- function(
     stop('all mixing matrix rows must sum to 1')
   }
   if (!all(lapply(1:length(parameters), function(x){approx_sum(mixing[,x], 1)}) == T)) {
-    print('warning: mixing matrix is asymmetrical')
+    warning('mixing matrix is asymmetrical')
   }
   if (is.null(correlations)) {
     correlations <- lapply(parameters, get_correlation_parameters)

--- a/R/model.R
+++ b/R/model.R
@@ -130,7 +130,8 @@ run_simulation <- function(
 #' @param correlations a list of correlation parameters for each population
 #' (default: NULL)
 #' @param mixing matrix of mixing coefficients for infectivity towards
-#' mosquitoes. Each element must be between 0 and 1 and all rows and columns must sum to 1.
+#' mosquitoes. Rows = origin sites, columns = destinations. Each element must 
+#' be between 0 and 1 and all rows must sum to 1.
 #' @return a list of dataframe of results
 #' @export
 run_metapop_simulation <- function(
@@ -146,11 +147,11 @@ run_metapop_simulation <- function(
   if (nrow(mixing) != length(parameters)) {
     stop('mixing matrix rows must match length of parameters')
   }
-  if (!all(round(rowSums(mixing), 1) == 1)) {
+  if (!all(lapply(1:length(parameters), function(x){approx_sum(mixing[x,], 1)}) == T)) {
     stop('all mixing matrix rows must sum to 1')
   }
-  if (!all(round(colSums(mixing), 1) == 1)) {
-    stop('all mixing matrix columns must sum to 1')
+  if (!all(lapply(1:length(parameters), function(x){approx_sum(mixing[,x], 1)}) == T)) {
+    print('warning: mixing matrix is asymmetrical')
   }
   if (is.null(correlations)) {
     correlations <- lapply(parameters, get_correlation_parameters)

--- a/R/model.R
+++ b/R/model.R
@@ -150,7 +150,7 @@ run_metapop_simulation <- function(
   if (!all(vlapply(seq_along(parameters), function(x) approx_sum(mixing[x,], 1)))) {
     stop('all mixing matrix rows must sum to 1')
   }
-  if (!all(lapply(1:length(parameters), function(x){approx_sum(mixing[,x], 1)}) == T)) {
+  if (!all(vlapply(seq_along(parameters), function(x) approx_sum(mixing[,x], 1)))) {
     warning('mixing matrix is asymmetrical')
   }
   if (is.null(correlations)) {

--- a/R/model.R
+++ b/R/model.R
@@ -147,7 +147,7 @@ run_metapop_simulation <- function(
   if (nrow(mixing) != length(parameters)) {
     stop('mixing matrix rows must match length of parameters')
   }
-  if (!all(lapply(1:length(parameters), function(x){approx_sum(mixing[x,], 1)}) == T)) {
+  if (!all(vlapply(seq_along(parameters), function(x) approx_sum(mixing[x,], 1)))) {
     stop('all mixing matrix rows must sum to 1')
   }
   if (!all(lapply(1:length(parameters), function(x){approx_sum(mixing[,x], 1)}) == T)) {

--- a/vignettes/Metapopulation.Rmd
+++ b/vignettes/Metapopulation.Rmd
@@ -70,7 +70,7 @@ mix_2 <- matrix(c(0.8, 0.1, 0.1,
                nrow = 3, ncol = 3)
 
 # perfectly-mixed
-mix_3 <- matrix(rep(.33, 9), nrow = 3, ncol = 3)
+mix_3 <- matrix(rep(1/3, 9), nrow = 3, ncol = 3)
 
 # run model
 set.seed(123)


### PR DESCRIPTION
Changes allow for asymmetrical mixing matricies
- replacing round() with approx_sum()
- keeping row sums == 1 error
- changing col sums error to a warning about asymmetrical aspects of matrix