### PR TITLE
Rendering for number of persons treated for clinical malaria or via MDA, SMC and PMC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: malariasimulation
 Title: An individual based model for malaria
-Version: 1.4.1
+Version: 1.4.2
 Authors@R: c(
   person(
     given = "Giovanni",

--- a/R/human_infection.R
+++ b/R/human_infection.R
@@ -78,7 +78,6 @@ simulate_infection <- function(
     renderer
   )
 
-  renderer$render('n_treated', treated$size(), timestep)
   renderer$render('n_infections', infected_humans$size(), timestep)
 
   schedule_infections(
@@ -276,6 +275,9 @@ calculate_treated <- function(
   renderer$render('ft', ft, timestep)
   seek_treatment <- sample_bitset(clinical_infections, ft)
   n_treat <- seek_treatment$size()
+  
+  renderer$render('n_treated', n_treat, timestep)
+  
   drugs <- as.numeric(parameters$clinical_treatment_drugs[
     sample.int(
       length(parameters$clinical_treatment_drugs),

--- a/R/mda_processes.R
+++ b/R/mda_processes.R
@@ -33,14 +33,14 @@ create_mda_listeners <- function(
     in_age <- which((age > min_ages[[time_index]]) & (age < max_ages[[time_index]]))
     target <- in_age[sample_intervention(in_age, int_name, coverage, correlations)]
 
+    renderer$render(paste0('n_', int_name, '_treated'), length(target), timestep)
+    
     successful_treatments <- bernoulli(
       length(target),
       parameters$drug_efficacy[[drug]]
     )
     to_move <- individual::Bitset$new(parameters$human_population)
     to_move$insert(target[successful_treatments])
-
-    renderer$render('n_mda_treated', to_move$size(), timestep)
 
     if (to_move$size() > 0) {
       # Move Diseased

--- a/R/pmc.R
+++ b/R/pmc.R
@@ -37,13 +37,14 @@ create_pmc_process <- function(
     in_age <- which(age %in% parameters$pmc_ages)
     target <- in_age[sample_intervention(in_age, 'pmc', coverage, correlations)]
     
+    renderer$render('n_pmc_treated', length(target), timestep)
+    
     successful_treatments <- bernoulli(
       length(target),
       parameters$drug_efficacy[[drug]]
     )
     to_move <- individual::Bitset$new(parameters$human_population)
     to_move$insert(target[successful_treatments])
-    renderer$render('n_pmc_treated', to_move$size(), timestep)
     
     if (to_move$size() > 0) {
       # Move Diseased


### PR DESCRIPTION
I believe that the `n_treated` outputs are mostly used to cost intervention programmes, it is therefore the number of treatments given, not the number of effective treatments given that should be output. This PR moves the rendering of `n_treated` outputs for clinical treatment, MDA, SMC and PMC to be prior to the drug-efficacy draw.

The PR also adds a distinction between MDA and SMC outputs which are now `n_mda_treated` and `n_smc_treated` respectively.

Fixes #189 

Please do let me know if you have heard of a use-case where users need the output after the drug effiacy draw.