### PR TITLE
Reduce mixed transmission with testing

### DIFF
--- a/R/biting_process.R
+++ b/R/biting_process.R
@@ -112,6 +112,10 @@ simulate_bites <- function(
     a <- .human_blood_meal_rate(f, s_i, W, parameters)
     lambda <- effective_biting_rates(a, .pi, p_bitten)
 
+    # calculate rdt coefficient to calculate the proportion of mixed
+    # transmission to include
+    rdt_negative <- 1 - rdt_detectable(variables, parameters, timestep)
+
     if (parameters$individual_mosquitoes) {
       species_index <- variables$species$get_index_of(
         parameters$species[[s_i]]
@@ -129,13 +133,22 @@ simulate_bites <- function(
     }
 
     # store the current population's EIR for later
-    lagged_eir[[mixing_index]][[s_i]]$save(n_infectious * a, timestep)
+    lagged_eir[[mixing_index]][[s_i]]$save(
+      n_infectious * a,
+      timestep
+    )
 
     # calculated the EIR for this timestep after mixing
     species_eir <- sum(
       vnapply(
-        lagged_eir,
-        function(l) l[[s_i]]$get(timestep - parameters$de)
+        seq_along(lagged_eir),
+        function(i) {
+          e <- lagged_eir[[i]][[s_i]]$get(timestep - parameters$de)
+          if (parameters$mixing_rdt && i != mixing_index) {
+            return(e * rdt_negative)
+          }
+          return(e)
+        }
       ) * mixing
     )
 
@@ -152,9 +165,16 @@ simulate_bites <- function(
     }
 
     infectivity <- vnapply(
-      lagged_infectivity,
-      function(l) l$get(timestep - parameters$delay_gam)
+      seq_along(lagged_infectivity),
+      function(i) {
+        inf <- lagged_infectivity[[i]]$get(timestep - parameters$delay_gam)
+        if (parameters$mixing_rdt && i != mixing_index) {
+              return(inf * rdt_negative)
+            }
+            return(inf)
+        }
     )
+
     lagged_infectivity[[mixing_index]]$save(
       sum(human_infectivity * .pi),
       timestep
@@ -308,4 +328,32 @@ unique_biting_rate <- function(age, parameters) {
 #' @noRd
 calculate_foim <- function(a, infectivity_sum, mixing) {
   a * sum(infectivity_sum * mixing)
+}
+
+# Estimates RDT prevalence from miscroscopy prevalence,
+# Wu et al 2015 Nature paper
+rdt_detectable <- function(variables, parameters, timestep) {
+  microscopy_prev <- calculate_detected(
+    variables$state,
+    variables$birth,
+    variables$id,
+    parameters,
+    timestep
+  )$size() / parameters$human_population
+  logit_prev <- log(microscopy_prev / (1 - microscopy_prev))
+  logit_rdt <- parameters$rdt_intercept + parameters$rdt_coeff * logit_prev
+  exp(logit_rdt) / (1 + exp(logit_rdt))
+}
+
+# return proportion of individuals detectable by microscopy
+calculate_detected <- function(state, birth, immunity, parameters, timestep) {
+  asymptomatic <- state$get_index_of('A')
+  prob <- probability_of_detection(
+    get_age(birth$get_values(asymptomatic), timestep),
+    immunity$get_values(asymptomatic),
+    parameters
+  )
+  asymptomatic_detected <- bitset_at(asymptomatic, bernoulli_multi_p(prob))
+  clinically_detected <- state$get_index_of(c('Tr', 'D'))
+  clinically_detected$or(asymptomatic_detected)
 }

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -217,6 +217,15 @@
 #' outputs; default = turned off
 #' * severe_incidence_rendering_max_ages - the corresponding max ages; default = turned off
 #'
+#' mixing:
+#'
+#' * mixing_rdt - boolean for whether mixing transmission should only consider
+#' individuals who would not be detected by an RDT test; default = FALSE
+#' * rdt_intercept - the y intercept for the log logit relationship betweeen rdt
+#' and microscopy prevalence; default = 0.108
+#' * rdt_coeff - the coefficient for the log logit relationship betweeen rdt
+#' and microscopy prevalence; default = 0.907
+#'
 #' miscellaneous:
 #'
 #' * human_population - the initial number of humans to model; default = 100
@@ -408,6 +417,10 @@ get_parameters <- function(overrides = list()) {
     severe_incidence_rendering_max_ages = numeric(0),
     age_group_rendering_min_ages = numeric(0),
     age_group_rendering_max_ages = numeric(0),
+    # mixing
+    mixing_rdt = FALSE,
+    rdt_intercept = 0.108,
+    rdt_coeff = 0.907,
     # misc
     custom_demography = FALSE,
     human_population = 100,

--- a/tests/testthat/test-biting-integration.R
+++ b/tests/testthat/test-biting-integration.R
@@ -183,3 +183,63 @@ test_that('simulate_bites works with mixed populations', {
 
   mockery::expect_args(mock_foim, 1, .3, c(.001, .01), c(.2, .8))
 })
+
+test_that('simulate_bites can halve the mixed transmission for 50% rdt detection', {
+  population <- 4
+  timestep <- 5
+  renderer <- individual::Render$new(5)
+  parameters <- get_parameters(
+    list(human_population = population, mixing_rdt = TRUE)
+  )
+  events <- create_events(parameters)
+  variables <- create_variables(parameters)
+
+  mock_rdt <- mockery::mock(.5) # 50%
+  mock_foim <- mockery::mock(1)
+  mock_pois <- mockery::mock(.3)
+  mock_a <- mockery::mock(.3)
+  mock_psi <- mockery::mock(rep(1, 4))
+
+  mockery::stub(simulate_bites, 'rdt_detectable', mock_rdt)
+  mockery::stub(simulate_bites, 'calculate_foim', mock_foim)
+  mockery::stub(simulate_bites, 'rpois', mock_pois)
+  mockery::stub(simulate_bites, '.human_blood_meal_rate', mock_a)
+  mockery::stub(simulate_bites, 'unique_biting_rate', mock_psi)
+  models <- parameterise_mosquito_models(parameters)
+  solvers <- parameterise_solvers(models, parameters)
+  lagged_foim <- list(LaggedValue$new(12.5, .001), LaggedValue$new(12.5, .01))
+  lagged_eir <- list(list(LaggedValue$new(12, 10)), list(LaggedValue$new(12, 10)))
+  age <- c(20, 24, 5, 39) * 365
+  bitten <- simulate_bites(
+    renderer,
+    solvers,
+    models,
+    variables,
+    events,
+    age,
+    parameters,
+    timestep,
+    lagged_foim,
+    lagged_eir,
+    c(0.2, 0.8),
+    2
+  )
+
+  mockery::expect_args(mock_foim, 1, .3, c(.0005, .01), c(.2, .8))
+  mockery::expect_args(mock_pois, 1, 1, 9) # = 10 * .2 * .5 + 10 * .8
+})
+
+test_that('rdt_detectable adjusts correctly with identity parameters', {
+  population <- 4
+  parameters <- get_parameters(
+    list(human_population = population, rdt_intercept = 0, rdt_coeff = 1)
+  )
+  variables <- create_variables(parameters)
+
+  mock_detected <- mockery::mock(individual::Bitset$new(4)$insert(c(1, 2))) # 50%
+
+  mockery::stub(rdt_detectable, 'calculate_detected', mock_detected)
+  rdt_prev <- rdt_detectable(variables, parameters, 1)
+
+  expect_equal(rdt_prev, 0.5)
+})


### PR DESCRIPTION
These changes add a `mixing_rdt` model parameter. When set to TRUE, the metapopulation model will reduce the transmission from external populations by the complement of the RDT prevalence in the external population.

Other parameters `rdt_intercept` and `rdt_coeff` should probably remain unchanged, they are set from Wu et al. 2015

Changes:

 * Add rdt testing parameters
 * Update biting_process to consider rdt testing for mixing
 * Add integration tests for rdt prevalence calculation and mixing reductions