### PR TITLE
Adding progress bar option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,15 +46,16 @@ Remotes:
   mrc-ide/malariaEquilibrium,
   mrc-ide/individual
 Imports:
-  individual (>= 0.1.7),
-  malariaEquilibrium (>= 1.0.1),
-  Rcpp,
-  statmod,
-  MASS,
-  dqrng,
-  sitmo,
-  BH,
-  R6
+    individual (>= 0.1.7),
+    malariaEquilibrium (>= 1.0.1),
+    Rcpp,
+    statmod,
+    MASS,
+    dqrng,
+    sitmo,
+    BH,
+    R6,
+    progress
 Suggests: 
   testthat,
   mockery,

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -417,7 +417,8 @@ get_parameters <- function(overrides = list()) {
     enable_heterogeneity = TRUE,
     r_tol = 1e-4,
     a_tol = 1e-4,
-    ode_max_steps = 1e6
+    ode_max_steps = 1e6,
+    progress_bar = FALSE
   )
 
   # Override parameters with any client specified ones

--- a/R/processes.R
+++ b/R/processes.R
@@ -20,18 +20,18 @@
 #' lagged transmission lists (default: 1)
 #' @noRd
 create_processes <- function(
-  renderer,
-  variables,
-  events,
-  parameters,
-  models,
-  solvers,
-  correlations,
-  lagged_eir,
-  lagged_infectivity,
-  mixing = 1,
-  mixing_index = 1
-  ) {
+    renderer,
+    variables,
+    events,
+    parameters,
+    models,
+    solvers,
+    correlations,
+    lagged_eir,
+    lagged_infectivity,
+    mixing = 1,
+    mixing_index = 1
+) {
   # ========
   # Immunity
   # ========
@@ -46,7 +46,7 @@ create_processes <- function(
     create_exponential_decay_process(variables$iva, parameters$rva),
     create_exponential_decay_process(variables$id, parameters$rid)
   )
-
+  
   if (parameters$individual_mosquitoes) {
     processes <- c(
       processes,
@@ -59,7 +59,7 @@ create_processes <- function(
       )
     )
   }
-
+  
   # ==============================
   # Biting and mortality processes
   # ==============================
@@ -112,7 +112,7 @@ create_processes <- function(
       0
     )
   )
-
+  
   # ===============
   # ODE integration
   # ===============
@@ -120,7 +120,7 @@ create_processes <- function(
     processes,
     create_solver_stepping_process(solvers, parameters)
   )
-
+  
   # =========
   # RTS,S EPI
   # =========
@@ -156,7 +156,7 @@ create_processes <- function(
       )
     )
   }
-
+  
   # =========
   # Rendering
   # =========
@@ -186,7 +186,7 @@ create_processes <- function(
     ),
     create_compartmental_rendering_process(renderer, solvers, parameters)
   )
-
+  
   if (parameters$individual_mosquitoes) {
     processes <- c(
       processes,
@@ -208,11 +208,11 @@ create_processes <- function(
       )
     )
   }
-
+  
   # ======================
   # Intervention processes
   # ======================
-
+  
   if (parameters$bednets) {
     processes <- c(
       processes,
@@ -225,14 +225,24 @@ create_processes <- function(
       net_usage_renderer(variables$net_time, renderer)
     )
   }
-
+  
   if (parameters$spraying) {
     processes <- c(
       processes,
       indoor_spraying(variables$spray_time, parameters, correlations)
     )
   }
-
+  
+  # ======================
+  # Progress bar process
+  # ======================
+  if (parameters$progress_bar){
+    processes <- c(
+      processes,
+      create_progress_process(timesteps)
+    )
+  }
+  
   processes
 }
 

--- a/R/progress.R
+++ b/R/progress.R
@@ -1,0 +1,14 @@
+#' Create progress process
+#'
+#' @param timesteps Simulation timesteps
+#'
+#' @return Progress bar process function
+create_progress_process <- function(timesteps){
+  pb <- progress::progress_bar$new(
+    format = "  running [:bar] :percent eta: :eta",
+    total = timesteps, clear = FALSE, width= 60)
+  
+  function(timestep) {
+    pb$tick()
+  }
+}


### PR DESCRIPTION
Adds in the option of a progress bar.

Currently defaulting to `FALSE` (no progress bar), as I don't know how to test properly esp for HPC use and there does seem to be some performance overhead (see plot)

Simple example:

```
timesteps <- 500

# No progress bar (defualt)
p <- get_parameters()
sim1 <- run_simulation(timesteps, p)

# Include progress bar
p2 <- p
p2$progress_bar <- TRUE
sim2 <- run_simulation(timesteps, p2)
```

![image](https://user-images.githubusercontent.com/16702715/218065163-18b091d1-0ecb-4894-b8b7-bdc52664be2d.png)


closes #212 
