### PR TITLE
Vignettes: Demography

### DIFF
--- a/vignettes/Demography.Rmd
+++ b/vignettes/Demography.Rmd
@@ -15,24 +15,38 @@ knitr::opts_chunk$set(
 ```
 
 ```{r setup}
-suppressPackageStartupMessages(library(ggplot2))
+# Load in the requisite package(s):
 library(malariasimulation)
 ```
 
-# Parameterisation
+# Introduction
 
-We are going to create a scenario where we track severe prevalence for 5 years.
+The dynamics of malaria transmission, and the efficacy of interventions designed to interrupt it, are highly context specific and an important consideration is the demography of the population(s) under investigation. To suit the research needs of the user, `malariasimulation` allows for the specification of custom human population demographics by allowing them to specify age-group specific death rates parameters. It also enables users to instruct the model to render output(s) with variables of interest (e.g. human population, number of cases detectable by microscopy, number of severe cases, etc.) presented by user-defined age groups. In this vignette we'll use simple, illustrative cases to demonstrate how to customise the output rendered by the `run_simulation()` function, specify a custom death rates, and, specify time-varying death rates.
+
+# Specifying human death rates by age group
+
+The `malariasimulation` package allows users to capture different human population demographies by specifying age-specific death rates. In the first section, we'll demonstrate how to instruct the model to output population and disease metrics by user-defined age groups and how to establish and run simulations with age-specific death rates. We'll illustrate the effect this has by comparing the demographic make-up of this custom parameterisation with that produced using the default parameters.
+
+## Default Parameterisation
+
+First, we'll establish a base set of parameters using the `get_parameters()` function and accepting the default values. The `run_simulation()` function's default behaviour is to output only the number of individuals aged 2-10 years old (`output$n_730_3650`). However, the user can instruct the model to output the number of individuals in age groups of their choosing using the `age_group_rendering_min_ages` and `age_group_rendering_max_ages` parameters. These arguments take vectors containing the minimum and maximum ages (in daily time steps) of the groups to be captured. To allow us to see the effect of changing demographic parameters, we'll use this functionality to output the number of individuals in ages groups ranging from 0 to 85 at 5 year intervals. Note that the same is possible for other model outputs, including the number (`n_detect` , `p_detect`, `n_severe`, `n_inc`, `p_inc`, `n_inc_clinical`, `p_inc_clinical`, `n_inc_severe`, and `p_inc_severe` ) using their equivalent min/max age-class rendering arguments (run `?run_simulation()` for more detail).
+
+We next use the `set_equilibrium()` function to tune the initial parameter set to that required to observe the specified initial entomological inoculation rate (`starting_EIR`). We now have a set of default parameters ready to use to run simulations.
 
 ```{r}
-year <- 365
-month <- 30
-sim_length <- 5 * year
+
+# Set the timespan over which to simulate
+year <- 365; years <- 5; sim_length <- year * years
+
+# Set an initial human population and initial entomological inoculation rate (EIR)
 human_population <- 1000
 starting_EIR <- 5
 
+# Set the age ranges (in days)
 age_min <- seq(0, 80, 5) * 365
 age_max <- seq(5, 85, 5) * 365
 
+# Use the get_parameters() function to establish the default simulation parameters, specifying age categories from 0-85 in 5 year intervals.
 simparams <- get_parameters(
   list(
     human_population = human_population,
@@ -41,55 +55,74 @@ simparams <- get_parameters(
   )
 )
 
+# Use set_equilibrium to tune the human and mosquito populations to those required for the defined EIR
 simparams <- set_equilibrium(simparams, starting_EIR)
+
 ```
 
-## Custom demography
+## **Custom Demographic Parameterisation**
 
-We can set a custom demography:
+Next, we'll use the the in-built `set_demography()` function to specify human death rates by age group. This function takes as inputs a parameter list to update, a vector of the age groups (in days) for which we specify death rates, a vector of time steps in which we want the death rates to be updated, and a matrix containing the death rates for each age group in each timestep. The `set_demography()` function appends these to the parameter list and updates the `custom_demography` parameter to `TRUE`.
 
 ```{r}
-demography_params <- simparams
 
-# Set a flat demography
-ages <- round(c(
-  .083333, 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80,
-  85, 90, 95, 200) * year)
+# Copy the simulation parameters as demography parameters:
+dem_params <- simparams
 
+# We can set our own custom demography:
+ages <- round(c(0.083333, 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 200) * year)
+
+# Set deathrates for each age group (looks like by taking annual values and dividing by 365:
 deathrates <- c(
   .4014834, .0583379, .0380348, .0395061, .0347255, .0240849, .0300902,
   .0357914, .0443123, .0604932, .0466799, .0426199, .0268332, .049361,
   .0234852, .0988317, .046755, .1638875, .1148753, .3409079, .2239224,
   .8338688) / 365
 
-demography_params <- set_demography(
-  demography_params,
+# Pass these custom ages and death rates through the in-built set_demography function 
+dem_params <- set_demography(
+  dem_params,
   agegroups = ages,
   timesteps = 0,
   deathrates = matrix(deathrates, nrow = 1)
 )
+
+# Confirm that the custom demography has been set:
+dem_params$custom_demography
+
 ```
 
-Let's run the simulations 
+## Simulations
+
+Having established parameter sets with both default and custom demographic parameterisations, we can now run a simulation for each using the `run_simulation()` function. We'll also add a column to each identify the runs.
 
 ```{r}
-# run and combine the outputs
+
+# Run the simulation with the default (?) demogaphic set-up
 exp_output <- run_simulation(sim_length, simparams)
 exp_output$run <- 'exponential'
-custom_output <- run_simulation(sim_length, demography_params)
+
+# Run the simulation for the custom demographic set-up
+custom_output <- run_simulation(sim_length, dem_params)
 custom_output$run <- 'custom'
+
+
 ```
 
-and now we can compare the age distributions in the populations
-in year 5:
+## Visualisation
 
-```{r}
-# wrangle outputs
-output <- rbind(exp_output, custom_output)
-output <- output[output$timestep == 5 * 365,]
+Using barplots, we can visualise the effect of altering the demographic parameters by comparing the distribution of people among the age-classes we instructed the model to output. The default parameterisation.
 
-# A function to extract the age variables and convert to long format
-convert_to_long <-  function(age_min, age_max, output){
+```{r, fig.width = 7.2, fig.height = 4, fig.fullwidth = TRUE}
+
+# Combine the two dataframes:
+dem_output <- rbind(exp_output, custom_output)
+
+# Select the final day of the simulation for each of the two demography runs:
+dem_output <- dem_output[dem_output$timestep == 5 * 365,]
+
+# Extract the age variables and convert the dataframe to long format:
+convert_to_long <- function(age_min, age_max, output) {
   output <- lapply(
     seq_along(age_min),
     function(i) {
@@ -97,60 +130,110 @@ convert_to_long <-  function(age_min, age_max, output){
         age_lower = age_min[[i]],
         age_upper = age_max[[i]],
         n = output[,paste0('n_age_', age_min[[i]], '_',age_max[[i]])],
-        age_mid = (age_min[[i]] + (age_min[[i]] - age_max[[i]]) / 2) / 365,
-        run = output$run, 
+        age_plot = age_min[[i]]/365,
+        run = output$run,
         timestep = output$timestep)
     }
   )
   output <- do.call("rbind", output)
 }
-output <- convert_to_long(age_min, age_max, output)
 
-# Plot the age distributions
-ggplot(output, aes(x = age_mid, y = n)) +
-  geom_bar(stat = "identity") +
-  theme_bw() +
-  facet_wrap(~ run)
+# Convert the output for plotting:
+dem_output <- convert_to_long(age_min, age_max, dem_output)
+
+# Define a colour palette for plotting:
+dem_cols <- c("#E69F00", "#56B4E9", "#009E73", "#CC79A7","#F0E442", "#0072B2", "#D55E00")
+
+# Define the plotting window
+par(mfrow = c(1, 2), mar = c(4, 4, 1, 1))
+
+# a) Default/Exponentially-distributed demography
+plot.new(); grid(lty = 1, col = "darkgrey", nx = 17, ny = 10, lwd = 0.5); par(new = TRUE)
+barplot(height = dem_output[dem_output$run == "exponential", c("n", "age_plot")]$n,
+        names = dem_output[dem_output$run == "exponential", c("n", "age_plot")]$age_plot,
+        axes = TRUE, space = 0, ylim = c(0, 250), xaxs = "i", yaxs = "i",
+        main = "Default", xlab = "Age Group", ylab = "Individuals",
+        cex.axis = 0.8, cex.lab = 1, cex.main = 1,
+        col = dem_cols[2]); box()
+
+# b) Custom demography
+plot.new()
+grid(lty = 1, col = "darkgrey", nx = 17, ny = 10, lwd = 0.5)
+par(new = TRUE)
+barplot(height = dem_output[dem_output$run == "custom", c("n", "age_plot")]$n,
+        names = dem_output[dem_output$run == "custom", c("n", "age_plot")]$age_plot,
+        axes = TRUE, space = 0, ylim = c(0, 250), xaxs = "i", yaxs = "i",
+        main = "Custom", xlab = "Age Group",
+        cex.axis = 0.8, cex.lab = 1, cex.main = 1,
+        col = dem_cols[1]); box()
+
 
 ```
 
-We can also specify time-varying death rates to capture a dynamic demography
+# Dynamic demography: time-varying death rates
 
-```{r, fig.width=7}
-dynamic_demography_params <- simparams
+Using the `timesteps` and `deathrates` arguments, we can also use the `set_demography()` function to update the death rates of specific age groups through time. In the following example, we'll use this functionality to first set our own initial death rates by age group, then instruct the model to increase the death rates in the age groups 5-10, 10-15, and 15-20 years old by a factor of 10. We'll finish by plotting the number of individuals in each age class at the end of each year to visualise the effect of time-varying death rates on the human population age-structure.
 
-# Set a flat demography
-ages <- round(c(
-  .083333, 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80,
-  85, 90, 95, 200) * year)
+## Parameterisation
 
-deathrates <- c(
-  .4014834, .0583379, .0380348, .0395061, .0347255, .0240849, .0300902,
-  .0357914, .0443123, .0604932, .0466799, .0426199, .0268332, .049361,
-  .0234852, .0988317, .046755, .1638875, .1148753, .3409079, .2239224,
-  .8338688) / 365
-# Let's increase the death rates in some age groups
-deathrates_changed <- deathrates
-deathrates_changed[3:6] <- deathrates_changed[3:6] * 10
+We'll start by making a copy of the base parameters which have been instructed to output the population size through time (`simparams`). Next, we create a version of the `deathrates` vector created earlier updated to increase the death rates of the 5-10, 10-15, and 15-20 age groups by 1000%. Finally, we use `set_demography()` to update our parameter list and specify our custom demography. This is achieved providing the `timesteps` argument with a vector of days to update the death rates (0 and 730 days), and providing `deathrates` with a matrix of death rates where each row corresponds to a set of death rates for a given update.
 
-dynamic_demography_params <- set_demography(
-  dynamic_demography_params,
+```{r}
+
+# Store the simulation parameters in a new object for modification
+dyn_dem_params <- simparams
+
+# Increase the death rates in some age groups (5-15 year olds):
+deathrates_increased <- deathrates
+deathrates_increased[3:6] <- deathrates_increased[3:6] * 10
+
+# Set the population demography using these updated deathrates
+dyn_dem_params <- set_demography(
+  dyn_dem_params,
   agegroups = ages,
-  timesteps = c(0, 2 * 365),
-  deathrates = matrix(c(deathrates, deathrates_changed), nrow = 2, byrow = TRUE)
+  timesteps = c(0, 2*365),
+  deathrates = matrix(c(deathrates, deathrates_increased), nrow = 2, byrow = TRUE)
 )
 
-dynamic_demography_output <- run_simulation(sim_length, dynamic_demography_params)
+```
 
-# wrangle outputs
-dynamic_demography_output <- dynamic_demography_output[dynamic_demography_output$timestep %in% (1:5 * 365),]
-dynamic_demography_output$run <- "dynamic"
+## Simulations
 
-dynamic_demography_output <- convert_to_long(age_min, age_max, dynamic_demography_output)
+```{r}
+# Run the simulation for the dynamic death rate demography
+dyn_dem_output <- run_simulation(sim_length, dyn_dem_params)
 
-# Plot the age distributions each year
-ggplot(dynamic_demography_output, aes(x = age_mid, y = n)) +
-  geom_bar(stat = "identity") +
-  theme_bw() +
-  facet_wrap(~ timestep / 365, ncol = 5)
+```
+
+## Visualisation
+
+Boxplots of the age structure of the human population at the end of each year show the marked effect that increasing the death rate within a small subset of age classes can have on the demography of the human population over time.
+
+```{r, fig.width = 7.2, fig.height = 3, fig.fullwidth = TRUE}
+
+# Filter out the end-of-year population sizes, add a column naming the run, and convert dataframe to long-form:
+dyn_dem_output <- dyn_dem_output[dyn_dem_output$timestep %in% (1:5 * 365),]
+dyn_dem_output$run <- 'dynamic'
+dyn_dem_output <- convert_to_long(age_min, age_max, dyn_dem_output)
+
+# Set a 1x5 plotting window:
+par(mfrow = c(1,5), mar = c(4, 4, 1, 1))
+
+# Loop through the years to plot:
+for(i in 1:5) {
+  plot.new()
+  grid(lty = 1, col = "darkgrey", nx = 11, ny = 10, lwd = 0.5)
+  par(new = TRUE)
+  barplot(height = dyn_dem_output[dyn_dem_output$timestep/365 == i,c("n", "age_plot")]$n,
+          names = dyn_dem_output[dyn_dem_output$timestep/365 == i,c("n", "age_plot")]$age_plot,
+          axes = TRUE, space = 0,
+          ylim = c(0, 500),
+          main = paste0("Year ", i), cex.main = 1.4,
+          xlab = ifelse(i == 3, "Age Group", ""),
+          ylab = ifelse(i == 1, "Individuals", ""),
+          xaxs = "i", yaxs = "i",
+          cex.axis = 0.8, cex.lab = 1, cex.main = 1, col = dem_cols[3])
+  box()
+}
+
 ```

--- a/vignettes/Demography.Rmd
+++ b/vignettes/Demography.Rmd
@@ -21,15 +21,15 @@ library(malariasimulation)
 
 # Introduction
 
-The dynamics of malaria transmission, and the efficacy of interventions designed to interrupt it, are highly context specific and an important consideration is the demography of the population(s) under investigation. To suit the research needs of the user, `malariasimulation` allows for the specification of custom human population demographics by allowing them to specify age-group specific death rates parameters. It also enables users to instruct the model to render output(s) with variables of interest (e.g. human population, number of cases detectable by microscopy, number of severe cases, etc.) presented by user-defined age groups. In this vignette we'll use simple, illustrative cases to demonstrate how to customise the output rendered by the `run_simulation()` function, specify a custom death rates, and, specify time-varying death rates.
+The dynamics of malaria transmission, and the efficacy of interventions designed to interrupt it, are highly context specific and an important consideration is the demography of the population(s) under investigation. To suit the research needs of the user, `malariasimulation` allows for the specification of custom human population demographics by allowing them to specify age-group specific death rates parameters. It also enables users to instruct the model to render outputs with variables of interest (e.g. human population, number of cases detectable by microscopy, number of severe cases, etc.) presented by user-defined age groups. In this vignette we'll use simple, illustrative cases to demonstrate how to customise the output rendered by the `run_simulation()` function, specify both fixed and time-varying custom death rates.
 
 # Specifying human death rates by age group
 
-The `malariasimulation` package allows users to capture different human population demographies by specifying age-specific death rates. In the first section, we'll demonstrate how to instruct the model to output population and disease metrics by user-defined age groups and how to establish and run simulations with age-specific death rates. We'll illustrate the effect this has by comparing the demographic make-up of this custom parameterisation with that produced using the default parameters.
+The `malariasimulation` package allows users to capture different human population demographies by specifying age-specific death rates. In the first section, we'll demonstrate how to instruct the model to output population and disease metrics by user-defined age groups and how to establish and run simulations with age-specific death rates. We'll illustrate the effect this has by comparing the demographic make-up of this custom parameterisation with that produced using the demographic profile established by the default parameters.
 
 ## Default Parameterisation
 
-First, we'll establish a base set of parameters using the `get_parameters()` function and accepting the default values. The `run_simulation()` function's default behaviour is to output only the number of individuals aged 2-10 years old (`output$n_730_3650`). However, the user can instruct the model to output the number of individuals in age groups of their choosing using the `age_group_rendering_min_ages` and `age_group_rendering_max_ages` parameters. These arguments take vectors containing the minimum and maximum ages (in daily time steps) of the groups to be captured. To allow us to see the effect of changing demographic parameters, we'll use this functionality to output the number of individuals in ages groups ranging from 0 to 85 at 5 year intervals. Note that the same is possible for other model outputs, including the number (`n_detect` , `p_detect`, `n_severe`, `n_inc`, `p_inc`, `n_inc_clinical`, `p_inc_clinical`, `n_inc_severe`, and `p_inc_severe` ) using their equivalent min/max age-class rendering arguments (run `?run_simulation()` for more detail).
+First, we'll establish a base set of parameters using the `get_parameters()` function and accepting the default values. The `run_simulation()` function's default behaviour is to output only the number of individuals aged 2-10 years old (`output$n_730_3650`, where 730 and 3650 are the ages in days). However, the user can instruct the model to output the number of individuals in age groups of their choosing using the `age_group_rendering_min_ages` and `age_group_rendering_max_ages` parameters. These arguments take vectors containing the minimum and maximum ages (in daily time steps) of each group to be captured. To allow us to see the effect of changing demographic parameters, we'll use this functionality to output the number of individuals in ages groups ranging from 0 to 85 at 5 year intervals. Note that the same is possible for other model outputs, including the number (`n_detect` , `p_detect`, `n_severe`, `n_inc`, `p_inc`, `n_inc_clinical`, `p_inc_clinical`, `n_inc_severe`, and `p_inc_severe` ) using their equivalent min/max age-class rendering arguments (run `?run_simulation()` for more detail).
 
 We next use the `set_equilibrium()` function to tune the initial parameter set to that required to observe the specified initial entomological inoculation rate (`starting_EIR`). We now have a set of default parameters ready to use to run simulations.
 
@@ -62,7 +62,7 @@ simparams <- set_equilibrium(simparams, starting_EIR)
 
 ## **Custom Demographic Parameterisation**
 
-Next, we'll use the the in-built `set_demography()` function to specify human death rates by age group. This function takes as inputs a parameter list to update, a vector of the age groups (in days) for which we specify death rates, a vector of time steps in which we want the death rates to be updated, and a matrix containing the death rates for each age group in each timestep. The `set_demography()` function appends these to the parameter list and updates the `custom_demography` parameter to `TRUE`.
+Next, we'll use the the in-built `set_demography()` function to specify human death rates by age group. This function accepts as inputs a parameter list to update, a vector of the age groups (in days) for which we specify death rates, a vector of time steps in which we want the death rates to be updated, and a matrix containing the death rates for each age group in each timestep. The `set_demography()` function appends these to the parameter list and updates the `custom_demography` parameter to `TRUE`.
 
 ```{r}
 
@@ -111,14 +111,14 @@ custom_output$run <- 'custom'
 
 ## Visualisation
 
-Using barplots, we can visualise the effect of altering the demographic parameters by comparing the distribution of people among the age-classes we instructed the model to output. The default parameterisation.
+Using barplots, we can visualise the effect of altering the demographic parameters by comparing the distribution of people among the age-classes we instructed the model to output on the final day of the simulation. The default demography is depicted in blue, while the custom demography is given in orange. Under the custom demography, the frequency in individuals in older age classes declines almost linearly, while in the default demography the number of individuals in each age class declines exponentially with age.
 
 ```{r, fig.width = 7.2, fig.height = 4, fig.fullwidth = TRUE}
 
 # Combine the two dataframes:
 dem_output <- rbind(exp_output, custom_output)
 
-# Select the final day of the simulation for each of the two demography runs:
+# Subset the final day of the simulation for each of the two demography runs:
 dem_output <- dem_output[dem_output$timestep == 5 * 365,]
 
 # Extract the age variables and convert the dataframe to long format:
@@ -172,7 +172,7 @@ barplot(height = dem_output[dem_output$run == "custom", c("n", "age_plot")]$n,
 
 # Dynamic demography: time-varying death rates
 
-Using the `timesteps` and `deathrates` arguments, we can also use the `set_demography()` function to update the death rates of specific age groups through time. In the following example, we'll use this functionality to first set our own initial death rates by age group, then instruct the model to increase the death rates in the age groups 5-10, 10-15, and 15-20 years old by a factor of 10. We'll finish by plotting the number of individuals in each age class at the end of each year to visualise the effect of time-varying death rates on the human population age-structure.
+Using the `timesteps` and `deathrates` arguments, we can also use the `set_demography()` function to update the death rates of specific age groups through time. In the following example, we'll use this functionality to first set our own initial death rates by age group, then instruct the model to increase the death rates in the age groups 5-10, 10-15, and 15-20 years old by a factor of 10 after 2 years. We'll finish by plotting the number of individuals in each age class at the end of each year to visualise the effect of time-varying death rates on the human population age-structure.
 
 ## Parameterisation
 
@@ -198,6 +198,7 @@ dyn_dem_params <- set_demography(
 ```
 
 ## Simulations
+Having established the parameter list for the dynamic death rate simulation, we can now run the simulation using the `run_simulation()` function.
 
 ```{r}
 # Run the simulation for the dynamic death rate demography

--- a/vignettes/Demography.Rmd
+++ b/vignettes/Demography.Rmd
@@ -197,7 +197,7 @@ dyn_dem_params <- set_demography(
 
 ```
 
-## Simulations
+## Simulation
 Having established the parameter list for the dynamic death rate simulation, we can now run the simulation using the `run_simulation()` function.
 
 ```{r}
@@ -208,7 +208,7 @@ dyn_dem_output <- run_simulation(sim_length, dyn_dem_params)
 
 ## Visualisation
 
-Boxplots of the age structure of the human population at the end of each year show the marked effect that increasing the death rate within a small subset of age classes can have on the demography of the human population over time.
+Bar plots of the age structure of the human population at the end of each year show the marked effect that increasing the death rate within a small subset of age classes can have on the demography of the human population over time.
 
 ```{r, fig.width = 7.2, fig.height = 3, fig.fullwidth = TRUE}
 

--- a/vignettes/Demography.Rmd
+++ b/vignettes/Demography.Rmd
@@ -21,7 +21,7 @@ library(malariasimulation)
 
 # Introduction
 
-The dynamics of malaria transmission, and the efficacy of interventions designed to interrupt it, are highly context specific and an important consideration is the demography of the population(s) under investigation. To suit the research needs of the user, `malariasimulation` allows for the specification of custom human population demographics by allowing them to specify age-group specific death rates parameters. It also enables users to instruct the model to render outputs with variables of interest (e.g. human population, number of cases detectable by microscopy, number of severe cases, etc.) presented by user-defined age groups. In this vignette we'll use simple, illustrative cases to demonstrate how to customise the output rendered by the `run_simulation()` function, specify both fixed and time-varying custom death rates.
+The dynamics of malaria transmission, and the efficacy of interventions designed to interrupt it, are highly context specific and an important consideration is the demography of the population(s) under investigation. To suit the research needs of the user, `malariasimulation` allows for the specification of custom human population demographics by allowing them to specify age-group specific death rates parameters. It also enables users to instruct the model to render outputs with variables of interest (e.g. human population, number of cases detectable by microscopy, number of severe cases, etc.) presented by user-defined age groups. In this vignette, we use simple, illustrative cases to demonstrate how to customise the output rendered by the `run_simulation()` function, and how to specify both fixed and time-varying custom death rates.
 
 # Specifying human death rates by age group
 
@@ -29,9 +29,9 @@ The `malariasimulation` package allows users to capture different human populati
 
 ## Default Parameterisation
 
-First, we'll establish a base set of parameters using the `get_parameters()` function and accepting the default values. The `run_simulation()` function's default behaviour is to output only the number of individuals aged 2-10 years old (`output$n_730_3650`, where 730 and 3650 are the ages in days). However, the user can instruct the model to output the number of individuals in age groups of their choosing using the `age_group_rendering_min_ages` and `age_group_rendering_max_ages` parameters. These arguments take vectors containing the minimum and maximum ages (in daily time steps) of each group to be captured. To allow us to see the effect of changing demographic parameters, we'll use this functionality to output the number of individuals in ages groups ranging from 0 to 85 at 5 year intervals. Note that the same is possible for other model outputs, including the number (`n_detect` , `p_detect`, `n_severe`, `n_inc`, `p_inc`, `n_inc_clinical`, `p_inc_clinical`, `n_inc_severe`, and `p_inc_severe` ) using their equivalent min/max age-class rendering arguments (run `?run_simulation()` for more detail).
+First, we'll establish a base set of parameters using the `get_parameters()` function and accept the default values. The `run_simulation()` function's default behaviour is to output only the number of individuals aged 2-10 years old (`output$n_730_3650`, where 730 and 3650 are the ages in days). However, the user can instruct the model to output the number of individuals in age groups of their choosing using the `age_group_rendering_min_ages` and `age_group_rendering_max_ages` parameters. These arguments take vectors containing the minimum and maximum ages (in daily time steps) of each age group to be rendered To allow us to see the effect of changing demographic parameters, we'll use this functionality to output the number of individuals in ages groups ranging from 0 to 85 at 5 year intervals. Note that the same is possible for other model outputs using their equivalent min/max age-class rendering arguments (`n_detect` , `p_detect`, `n_severe`, `n_inc`, `p_inc`, `n_inc_clinical`, `p_inc_clinical`, `n_inc_severe`, and `p_inc_severe`, run `?run_simulation()` for more detail).
 
-We next use the `set_equilibrium()` function to tune the initial parameter set to that required to observe the specified initial entomological inoculation rate (`starting_EIR`). We now have a set of default parameters ready to use to run simulations.
+We next use the `set_equilibrium()` function to tune the initial parameter set to those required to observe the specified initial entomological inoculation rate (`starting_EIR`) at equilibrium. We now have a set of default parameters ready to use to run simulations.
 
 ```{r}
 
@@ -46,7 +46,8 @@ starting_EIR <- 5
 age_min <- seq(0, 80, 5) * 365
 age_max <- seq(5, 85, 5) * 365
 
-# Use the get_parameters() function to establish the default simulation parameters, specifying age categories from 0-85 in 5 year intervals.
+# Use the get_parameters() function to establish the default simulation parameters, specifying
+# age categories from 0-85 in 5 year intervals.
 simparams <- get_parameters(
   list(
     human_population = human_population,
@@ -55,14 +56,15 @@ simparams <- get_parameters(
   )
 )
 
-# Use set_equilibrium to tune the human and mosquito populations to those required for the defined EIR
+# Use set_equilibrium to tune the human and mosquito populations to those required for the
+# defined EIR
 simparams <- set_equilibrium(simparams, starting_EIR)
 
 ```
 
 ## **Custom Demographic Parameterisation**
 
-Next, we'll use the the in-built `set_demography()` function to specify human death rates by age group. This function accepts as inputs a parameter list to update, a vector of the age groups (in days) for which we specify death rates, a vector of time steps in which we want the death rates to be updated, and a matrix containing the death rates for each age group in each timestep. The `set_demography()` function appends these to the parameter list and updates the `custom_demography` parameter to `TRUE`.
+Next, we'll use the the in-built `set_demography()` function to specify human death rates by age group. This function accepts as inputs a parameter list to update, a vector of the age groups (in days) for which we specify death rates, a vector of time steps in which we want the death rates to be updated, and a matrix containing the death rates for each age group in each timestep. The `set_demography()` function appends these to the parameter list and updates the `custom_demography` parameter to `TRUE`. Here, we instruct the model to implement these changes to the demographic  parameters at the beginning of the simulation (`timesteps = 0`).
 
 ```{r}
 
@@ -70,7 +72,8 @@ Next, we'll use the the in-built `set_demography()` function to specify human de
 dem_params <- simparams
 
 # We can set our own custom demography:
-ages <- round(c(0.083333, 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 200) * year)
+ages <- round(c(0.083333, 1, 5, 10, 15, 20, 25, 30, 35, 40, 45,
+                50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 200) * year)
 
 # Set deathrates for each age group (looks like by taking annual values and dividing by 365:
 deathrates <- c(
@@ -79,7 +82,9 @@ deathrates <- c(
   .0234852, .0988317, .046755, .1638875, .1148753, .3409079, .2239224,
   .8338688) / 365
 
-# Pass these custom ages and death rates through the in-built set_demography function 
+# Update the parameter list with the custom ages and death rates through the in-built
+# set_demography() function, instructing the custom demography to be implemented at the
+# beginning of the model run (timestep = 0):
 dem_params <- set_demography(
   dem_params,
   agegroups = ages,
@@ -98,11 +103,11 @@ Having established parameter sets with both default and custom demographic param
 
 ```{r}
 
-# Run the simulation with the default (?) demogaphic set-up
+# Run the simulation with the default demographic set-up:
 exp_output <- run_simulation(sim_length, simparams)
 exp_output$run <- 'exponential'
 
-# Run the simulation for the custom demographic set-up
+# Run the simulation for the custom demographic set-up:
 custom_output <- run_simulation(sim_length, dem_params)
 custom_output$run <- 'custom'
 
@@ -176,7 +181,7 @@ Using the `timesteps` and `deathrates` arguments, we can also use the `set_demog
 
 ## Parameterisation
 
-We'll start by making a copy of the base parameters which have been instructed to output the population size through time (`simparams`). Next, we create a version of the `deathrates` vector created earlier updated to increase the death rates of the 5-10, 10-15, and 15-20 age groups by 1000%. Finally, we use `set_demography()` to update our parameter list and specify our custom demography. This is achieved providing the `timesteps` argument with a vector of days to update the death rates (0 and 730 days), and providing `deathrates` with a matrix of death rates where each row corresponds to a set of death rates for a given update.
+We'll start by making a copy of the base parameters which have been instructed to output the population size through time (`simparams`). Next, we create a version of the `deathrates` vector created earlier updated to increase the death rates of the 5-10, 10-15, and 15-20 age groups by 10%. Finally, we use `set_demography()` to update our parameter list and specify our custom demography. This is achieved providing the `timesteps` argument with a vector of days to update the death rates (0 and 730 days), and providing `deathrates` with a matrix of death rates where each row corresponds to a set of death rates for a given update.
 
 ```{r}
 
@@ -212,7 +217,8 @@ Bar plots of the age structure of the human population at the end of each year s
 
 ```{r, fig.width = 7.2, fig.height = 3, fig.fullwidth = TRUE}
 
-# Filter out the end-of-year population sizes, add a column naming the run, and convert dataframe to long-form:
+# Filter out the end-of-year population sizes, add a column naming the run, and convert
+# dataframe to long-form:
 dyn_dem_output <- dyn_dem_output[dyn_dem_output$timestep %in% (1:5 * 365),]
 dyn_dem_output$run <- 'dynamic'
 dyn_dem_output <- convert_to_long(age_min, age_max, dyn_dem_output)


### PR DESCRIPTION
The demography vignette has been updated to remove the dependency on ggplot2 by recreating the figures using base R plotting functions, add more detailed textual explanations of the examples in the vignette, and improve the structure of the vignette.

Figures:
The figures have been recreated using base R plotting functions and their colours brought in line with the scheme used across the vignette updates.

Code Chunks:
The code chunks have been tidied and commented more extensively to ensure readers can follow the steps.

Text:
An introduction section has been added to explain the purpose of the vignette and outline its contents. The vignette has been broadly divided into two sections, static and time-varying custom death rates. Within these sections, additional subsections have been included to help highlight a logical order of steps when running malariasimulation. Each section has had the textual explanation expanded to be more informative to the reader.
