### PR TITLE
Fix min_wait bug in set_mass_pev()

### DIFF
--- a/R/pev.R
+++ b/R/pev.R
@@ -83,7 +83,7 @@ create_mass_pev_listener <- function(
     if (parameters$mass_pev_min_wait == 0) {
       target <- in_age_group$to_vector()
     } else {
-      not_recently_vaccinated <- variables$vaccinated_timestep$get_index_of(
+      not_recently_vaccinated <- variables$pev_timestep$get_index_of(
         a = max(timestep - parameters$mass_pev_min_wait, 0),
         b = timestep
       )$not(TRUE)

--- a/vignettes/Vaccines.Rmd
+++ b/vignettes/Vaccines.Rmd
@@ -39,7 +39,6 @@ simparams <- get_parameters(list(
 )
 
 simparams <- set_equilibrium(simparams, starting_EIR)
-
 ```
 
 Then we can run the simulation for a variety of vaccination strategies:


### PR DESCRIPTION
I updated the variable that set_mass_pev() uses to calculate if the individual has been recently vaccinated. 

I tested locally that this did not throw errors anymore by running this: 

```
params <- get_parameters(list(
  human_population = 1000,
  model_seasonality = FALSE
))

params <- params <- set_mass_pev(
  parameters = params,
  profile = rtss_profile,
  timesteps = c(1,100, 200),
  coverages = rep(0.8, 3),
  min_ages = 5* 30,
  max_ages = 17* 30,
  min_wait = 365,
  booster_timestep = 100,
  booster_coverage = 0.64,,
  booster_profile = list(rtss_booster_profile))

out <- run_simulation(timesteps = 365*2,
                      params)
```
