### PR TITLE
Check drug inputs are a list

### DIFF
--- a/R/drug_parameters.R
+++ b/R/drug_parameters.R
@@ -24,6 +24,7 @@ SP_AQ_params <- c(0.9, 0.32, 4.3, 38.1)
 #' @param drugs a list of drug parameters, can be set using presets
 #' @export
 set_drugs <- function(parameters, drugs) {
+  stopifnot(is.list(drugs))
   keys <- c(
     'drug_efficacy',
     'drug_rel_c',

--- a/tests/testthat/test-treatment.R
+++ b/tests/testthat/test-treatment.R
@@ -78,3 +78,12 @@ test_that('You cannot set invalid coverages', {
     )
   )
 })
+
+test_that('set_drugs errors if a list is not provided', {
+  parameters <- get_parameters()
+  expect_error(
+    set_drugs(parameters, AL_params),
+    "is.list(drugs) is not TRUE",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
Adds a check that the drugs arguments for `set_drugs()` must be a list. Previously a single drug profile could be provided and was accepted that led to hard to diagnose simulation errors.

Fixes #241 

(Will also fix #242 when merged in)