### PR TITLE
Clarify description of argument for booster coverage

### DIFF
--- a/R/pev_parameters.R
+++ b/R/pev_parameters.R
@@ -73,7 +73,7 @@ rtss_booster_profile <- create_pev_profile(
 #' both set_mass_pev and set_pev_epi, this represents the minimum time between
 #' an individual being vaccinated under one scheme and vaccinated under another.
 #' @param booster_timestep the timesteps (following the final dose) at which booster vaccinations are administered
-#' @param booster_coverage the proportion of the vaccinated population who will
+#' @param booster_coverage the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
 #' receive each booster vaccine
 #' @param booster_profile list of booster vaccine profiles, of type
 #' PEVProfile, for each timestep in booster_timeteps
@@ -149,7 +149,7 @@ set_pev_epi <- function(
 #' @param min_ages for the target population, inclusive (in timesteps)
 #' @param max_ages for the target population, inclusive (in timesteps)
 #' @param booster_timestep the timesteps (following the initial vaccination) at which booster vaccinations are administered
-#' @param booster_coverage the proportion of the vaccinated population who will
+#' @param booster_coverage  the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
 #' receive each booster vaccine
 #' @param booster_profile list of booster vaccine profiles, of type
 #' PEVProfile, for each timestep in booster_timeteps

--- a/R/pev_parameters.R
+++ b/R/pev_parameters.R
@@ -73,8 +73,7 @@ rtss_booster_profile <- create_pev_profile(
 #' both set_mass_pev and set_pev_epi, this represents the minimum time between
 #' an individual being vaccinated under one scheme and vaccinated under another.
 #' @param booster_timestep the timesteps (following the final dose) at which booster vaccinations are administered
-#' @param booster_coverage the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
-#' receive each booster vaccine
+#' @param booster_coverage the proportion of the vaccinated population relative to the last vaccination (whether a previous booster or the primary series)
 #' @param booster_profile list of booster vaccine profiles, of type
 #' PEVProfile, for each timestep in booster_timeteps
 #' @param seasonal_boosters logical, if TRUE the first booster timestep is
@@ -149,8 +148,7 @@ set_pev_epi <- function(
 #' @param min_ages for the target population, inclusive (in timesteps)
 #' @param max_ages for the target population, inclusive (in timesteps)
 #' @param booster_timestep the timesteps (following the initial vaccination) at which booster vaccinations are administered
-#' @param booster_coverage the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
-#' receive each booster vaccine
+#' @param booster_coverage the proportion of the vaccinated population relative to the last vaccination (whether a previous booster or the primary series)
 #' @param booster_profile list of booster vaccine profiles, of type
 #' PEVProfile, for each timestep in booster_timeteps
 #' @export

--- a/R/pev_parameters.R
+++ b/R/pev_parameters.R
@@ -149,7 +149,7 @@ set_pev_epi <- function(
 #' @param min_ages for the target population, inclusive (in timesteps)
 #' @param max_ages for the target population, inclusive (in timesteps)
 #' @param booster_timestep the timesteps (following the initial vaccination) at which booster vaccinations are administered
-#' @param booster_coverage  the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
+#' @param booster_coverage the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
 #' receive each booster vaccine
 #' @param booster_profile list of booster vaccine profiles, of type
 #' PEVProfile, for each timestep in booster_timeteps

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -20,7 +20,7 @@ fixed state transitions:
 \item dl - the delay for mosquitoes to move from state L to P; default = 3.72
 \item dpl - the delay mosquitoes to move from state P to Sm; default = 0.643
 \item mup - the rate at which pupal mosquitoes die; default = 0.249
-\item mum - the rate at which developed mosquitoes die; default = 0.1253333
+\item mum - the rate at which developed mosquitoes die; default (An. gambiae) = .132
 }
 
 immunity decay rates:
@@ -151,9 +151,9 @@ species specific values are vectors
 \item beta - the average number of eggs laid per female mosquito per day; default = 21.2
 \item total_M - the initial number of adult mosquitos in the simulation; default = 1000
 \item init_foim - the FOIM used to calculate the equilibrium state for mosquitoes; default = 0
-\item species - names of the species in the simulation; default = "All"
+\item species - names of the species in the simulation; default = "gamb"
 \item species_proportions - the relative proportions of each species; default = 1
-\item blood_meal_rates - the blood meal rates for each species; default = 0.3333333333
+\item blood_meal_rates - the blood meal rates for each species; default = 1/3
 \item Q0 - proportion of blood meals taken on humans; default = 0.92
 \item foraging_time - time spent taking blood meals; default = 0.69
 }

--- a/man/set_mass_pev.Rd
+++ b/man/set_mass_pev.Rd
@@ -36,8 +36,7 @@ time between an individual being vaccinated under one scheme and vaccinated unde
 
 \item{booster_timestep}{the timesteps (following the initial vaccination) at which booster vaccinations are administered}
 
-\item{booster_coverage}{the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
-receive each booster vaccine}
+\item{booster_coverage}{the proportion of the vaccinated population relative to the last vaccination (whether a previous booster or the primary series)}
 
 \item{booster_profile}{list of booster vaccine profiles, of type
 PEVProfile, for each timestep in booster_timeteps}

--- a/man/set_mass_pev.Rd
+++ b/man/set_mass_pev.Rd
@@ -36,7 +36,7 @@ time between an individual being vaccinated under one scheme and vaccinated unde
 
 \item{booster_timestep}{the timesteps (following the initial vaccination) at which booster vaccinations are administered}
 
-\item{booster_coverage}{the proportion of the vaccinated population who will
+\item{booster_coverage}{the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
 receive each booster vaccine}
 
 \item{booster_profile}{list of booster vaccine profiles, of type

--- a/man/set_pev_epi.Rd
+++ b/man/set_pev_epi.Rd
@@ -37,7 +37,7 @@ an individual being vaccinated under one scheme and vaccinated under another.}
 
 \item{booster_timestep}{the timesteps (following the final dose) at which booster vaccinations are administered}
 
-\item{booster_coverage}{the proportion of the vaccinated population who will
+\item{booster_coverage}{the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
 receive each booster vaccine}
 
 \item{booster_profile}{list of booster vaccine profiles, of type

--- a/man/set_pev_epi.Rd
+++ b/man/set_pev_epi.Rd
@@ -37,8 +37,7 @@ an individual being vaccinated under one scheme and vaccinated under another.}
 
 \item{booster_timestep}{the timesteps (following the final dose) at which booster vaccinations are administered}
 
-\item{booster_coverage}{the proportion of the vaccinated population relative to the last vaccination whether booster or primary series who will
-receive each booster vaccine}
+\item{booster_coverage}{the proportion of the vaccinated population relative to the last vaccination (whether a previous booster or the primary series)}
 
 \item{booster_profile}{list of booster vaccine profiles, of type
 PEVProfile, for each timestep in booster_timeteps}


### PR DESCRIPTION
It was unclear in the booster coverage argument for `set_pev_epi` and `set_mass_pev` if a list of booster coverages c(0.8, 0.9, 0.9, 0.9) was relative to the vaccinated population from the primary series or relative to the most recent vaccination. I did some tests and believe that this example above would give the first booster to 80% of those who received the primary series, then the second booster to 90% of those who received the first booster, and the 3rd booster to 90% of those who received the second booster, and so on. I'm proposing updates to the argument description to reflect that. 

I have added code below to show what I did to test this.

```
library(malariasimulation)
library(dplyr)
library(tidyr)
library(ggplot2)

# assign values
population = 1000
seasonality = list(c(0.2852770, -0.0248801, -0.0529426, -0.0168910, -0.0216681, -0.0242904, -0.0073646))
seas_name = 'seasonal'
warmup = 1*365
sim_length = 12*365

year <- 365
month <- year / 12
program_start <- 365

params <- get_parameters(list(
  human_population = population,
  model_seasonality = TRUE,
  # rainfall fourier parameters
  g0 = unlist(seasonality)[1],
  g = unlist(seasonality)[2:4],
  h = unlist(seasonality)[5:7],
  individual_mosquitoes = FALSE))

params$pev_doses <- round(c(0, 1.5 * month, 3 * month)) # spacing from the RTSS work 

peak <- peak_season_offset(params)

# Set mass booster timesteps
massboosters <- round(seq(12, 48, by = 12) * month) # 4 annual boosters after 3rd dose

# Set mass booster coverage: 
massbooster_cov <- c(0.8, rep(0.9, length(massboosters)-1))

first <- round(warmup + program_start + (peak - month * 3.5), 0) # after program start, 3.5 months prior to peak for seasonal 

pevtimesteps <- c(first)

# Set mass vaccination 
# add mass vaccination 
params <- set_mass_pev(
  parameters = params,
  profile = rtss_profile,
  timesteps = pevtimesteps, 
  coverages = rep(0.8, length(pevtimesteps)), 
  min_ages = 5*year,
  max_ages = 100*year,
  min_wait = 0,
  booster_timestep = massboosters, # timesteps following initial vaccination 
  booster_profile = list(rtss_booster_profile, rtss_booster_profile, rtss_booster_profile, rtss_booster_profile),
  booster_coverage = massbooster_cov 
)

o <- run_simulation(timesteps = sim_length+warmup, parameters = params)

# plot doses
doses <- o |> 
  select(timestep, starts_with('n_pev')) |>
  pivot_longer(starts_with('n_pev'), names_to = "dose", values_to = "count") |>
  mutate(month = ceiling(timestep / month)) |>
  group_by(month, dose) |>
  summarize(count = sum(count))

ggplot(data = doses) + 
  geom_col(aes(x = month/12, y = count, fill = dose)) +
  xlab("month") +
  ylab("doses") +
  theme_bw()

d <- o %>%
  mutate(month = ceiling(timestep / month)) |>
  group_by(month) %>%
  summarize(across(starts_with("n_pev"), sum))
```