### PR TITLE
Bug/maternal immunity sampling

### DIFF
--- a/R/mortality_processes.R
+++ b/R/mortality_processes.R
@@ -66,7 +66,7 @@ sample_maternal_immunity <- function(variables, target, timestep, parameters) {
 
         # set their maternal immunities
         birth_icm <- variables$ica$get_values(mothers) * parameters$pcm
-        birth_ivm <- variables$ica$get_values(mothers) * parameters$pvm
+        birth_ivm <- variables$iva$get_values(mothers) * parameters$pvm
         variables$icm$queue_update(birth_icm, target_group)
         variables$ivm$queue_update(birth_ivm, target_group)
       }


### PR DESCRIPTION
The sample_maternal_immunity() function (in mortality_processes.R), which samples and assigns maternally-inherited immunity to clinical (icm) and severe (ivm) disease for a Bitset of target individuals (in practice those who have died and are being re-born into the population) currently calculates the maternally-inherited immunity to clinical and severe disease as follows:

```
birth_icm <- variables$ica$get_values(mothers) * parameters$pcm
birth_ivm <- variables$ica$get_values(mothers) * parameters$pvm
```

I think maternally inherited immunity to severe disease (birth_ivm) should presumably be calculated using the mothers acquired immunity to severe disease variables$iva), so have amended the calculation for maternally-inherited immunity to severe disease to the following:

`birth_ivm <- variables$iva$get_values(mothers) * parameters$pvm`


