### PR TITLE
Added check for undeveloped antimalarial resistance features (SPC/LPF…

### DIFF
--- a/R/antimalarial_resistance.R
+++ b/R/antimalarial_resistance.R
@@ -26,6 +26,14 @@ set_antimalarial_resistance <- function(parameters,
                                         reinfection_prob,
                                         slow_parasite_clearance_time) {
   
+  if(any(partner_drug_resistance > 0,
+         slow_parasite_clearance_prob > 0,
+         late_clinical_failure_prob > 0,
+         late_parasitological_prob > 0,
+         reinfection_prob > 0)) {
+    stop("Parameters set for unimplemented feature - late clinical failure, late parasitological failure, or reinfection during prophylaxis")
+  }
+  
   if(any(c(length(artemisinin_resistance),
            length(partner_drug_resistance), 
            length(slow_parasite_clearance_prob), 
@@ -48,8 +56,8 @@ set_antimalarial_resistance <- function(parameters,
          reinfection_prob < 0 | reinfection_prob > 1)) {
     stop("Resistance outcome probabilities must fall between 0 and 1")
   }
-
-    if(length(slow_parasite_clearance_time) != 1) {
+  
+  if(length(slow_parasite_clearance_time) != 1) {
     stop("Error: length of slow_parasite_clearance_time not equal to 1")
   }
   

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -201,13 +201,13 @@
 #' * antimalarial_resistance_drug - vector of drugs for which resistance can be parameterised; default = NULL
 #' * antimalarial_resistance_timesteps - vector of time steps on which resistance updates occur; default = NULL
 #' * prop_artemisinin_resistant - vector of proportions of infections resistant to the artemisinin component of a given drug; default = NULL
-#' * prop_partner_drug_resistant - vector of proportions of infections resistant to the parter drug component of a given drug; default = NULL
-#' * slow_parasite_clearance_prob - vector of probabilities of slow parasite clearance for a given drug; default = NULL
+#' * prop_partner_drug_resistant - vector of proportions of infections resistant to the parter drug component of a given drug; default = NULL (currently unimplemented)
+#' * slow_parasite_clearance_prob - vector of probabilities of slow parasite clearance for a given drug; default = NULL (currently unimplemented)
 #' * early_treatment_failure_prob - vector of probabilities of early treatment failure for a given drug; default = NULL
-#' * late_clinical_failure_prob - vector of probabilities of late clinical failure for a given drug; default = NULL
-#' * late_parasitological_failure_prob - vector of probabilities of late parasitological failure for a given drug; default = NULL
-#' * reinfection_during_prophylaxis - vector of probabilities of reinfection during prophylaxis for a given drug; default = NULL
-#' * dt_slow_parasite_clearance - the delay for humans experiencing slow parasite clearance to move from state Tr to S; default = NULL
+#' * late_clinical_failure_prob - vector of probabilities of late clinical failure for a given drug; default = NULL (currently unimplemented)
+#' * late_parasitological_failure_prob - vector of probabilities of late parasitological failure for a given drug; default = NULL (currently unimplemented)
+#' * reinfection_during_prophylaxis - vector of probabilities of reinfection during prophylaxis for a given drug; default = NULL (currently unimplemented)
+#' * dt_slow_parasite_clearance - the delay for humans experiencing slow parasite clearance to move from state Tr to S; default = NULL (currently unimplemented)
 #'
 #' rendering:
 #' All values are in timesteps and all ranges are inclusive

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -222,13 +222,13 @@ please set antimalarial resistance parameters with the convenience functions in
 \item antimalarial_resistance_drug - vector of drugs for which resistance can be parameterised; default = NULL
 \item antimalarial_resistance_timesteps - vector of time steps on which resistance updates occur; default = NULL
 \item prop_artemisinin_resistant - vector of proportions of infections resistant to the artemisinin component of a given drug; default = NULL
-\item prop_partner_drug_resistant - vector of proportions of infections resistant to the parter drug component of a given drug; default = NULL
-\item slow_parasite_clearance_prob - vector of probabilities of slow parasite clearance for a given drug; default = NULL
+\item prop_partner_drug_resistant - vector of proportions of infections resistant to the parter drug component of a given drug; default = NULL (currently unimplemented)
+\item slow_parasite_clearance_prob - vector of probabilities of slow parasite clearance for a given drug; default = NULL (currently unimplemented)
 \item early_treatment_failure_prob - vector of probabilities of early treatment failure for a given drug; default = NULL
-\item late_clinical_failure_prob - vector of probabilities of late clinical failure for a given drug; default = NULL
-\item late_parasitological_failure_prob - vector of probabilities of late parasitological failure for a given drug; default = NULL
-\item reinfection_during_prophylaxis - vector of probabilities of reinfection during prophylaxis for a given drug; default = NULL
-\item dt_slow_parasite_clearance - the delay for humans experiencing slow parasite clearance to move from state Tr to S; default = NULL
+\item late_clinical_failure_prob - vector of probabilities of late clinical failure for a given drug; default = NULL (currently unimplemented)
+\item late_parasitological_failure_prob - vector of probabilities of late parasitological failure for a given drug; default = NULL (currently unimplemented)
+\item reinfection_during_prophylaxis - vector of probabilities of reinfection during prophylaxis for a given drug; default = NULL (currently unimplemented)
+\item dt_slow_parasite_clearance - the delay for humans experiencing slow parasite clearance to move from state Tr to S; default = NULL (currently unimplemented)
 }
 
 rendering:

--- a/tests/testthat/test-antimalarial-resistance.R
+++ b/tests/testthat/test-antimalarial-resistance.R
@@ -10,11 +10,11 @@ test_that('set_antimalarial_resistance() toggles resistance on', {
                               timesteps = 1,
                               artemisinin_resistance = 0.5,
                               partner_drug_resistance = 0,
-                              slow_parasite_clearance_prob = 0.5,
+                              slow_parasite_clearance_prob = 0,
                               early_treatment_failure_prob = 0.6,
-                              late_clinical_failure_prob = 0.2,
-                              late_parasitological_prob = 0.3,
-                              reinfection_prob = 0.4, 
+                              late_clinical_failure_prob = 0,
+                              late_parasitological_prob = 0,
+                              reinfection_prob = 0, 
                               slow_parasite_clearance_time = 10) -> simparams
   expect_identical(object = simparams$antimalarial_resistance, expected = TRUE)
 })
@@ -31,11 +31,11 @@ test_that('set_antimalarial_resistance() errors if parameter inputs of different
                                                      timesteps = c(1, 10),
                                                      artemisinin_resistance = 0.5,
                                                      partner_drug_resistance = 0,
-                                                     slow_parasite_clearance_prob = 0.5,
+                                                     slow_parasite_clearance_prob = 0,
                                                      early_treatment_failure_prob = 0.6,
-                                                     late_clinical_failure_prob = 0.2,
-                                                     late_parasitological_prob = 0.3,
-                                                     reinfection_prob = 0.4,
+                                                     late_clinical_failure_prob = 0,
+                                                     late_parasitological_prob = 0,
+                                                     reinfection_prob = 0,
                                                      slow_parasite_clearance_time = 10))
 })
 
@@ -51,11 +51,11 @@ test_that('set_antimalarial_resistance() errors if resistance proportions outsid
                                                      timesteps = 1,
                                                      artemisinin_resistance = 1.01,
                                                      partner_drug_resistance = 0,
-                                                     slow_parasite_clearance_prob = 0.5,
+                                                     slow_parasite_clearance_prob = 0,
                                                      early_treatment_failure_prob = 0.6,
-                                                     late_clinical_failure_prob = 0.2,
-                                                     late_parasitological_prob = 0.3,
-                                                     reinfection_prob = 0.4,
+                                                     late_clinical_failure_prob = 0,
+                                                     late_parasitological_prob = 0,
+                                                     reinfection_prob = 0,
                                                      slow_parasite_clearance_time = 10), 
                regexp = "Artemisinin and partner-drug resistance proportions must fall between 0 and 1")
 })
@@ -72,11 +72,11 @@ test_that('set_antimalarial_resistance() errors if resistance phenotype probabil
                                                      timesteps = 1,
                                                      artemisinin_resistance = 0.4,
                                                      partner_drug_resistance = 0,
-                                                     slow_parasite_clearance_prob = -0.5,
-                                                     early_treatment_failure_prob = 0.6,
-                                                     late_clinical_failure_prob = 0.2,
-                                                     late_parasitological_prob = 0.3,
-                                                     reinfection_prob = 0.4, 
+                                                     slow_parasite_clearance_prob = 0,
+                                                     early_treatment_failure_prob = -0.6,
+                                                     late_clinical_failure_prob = 0,
+                                                     late_parasitological_prob = 0,
+                                                     reinfection_prob = 0, 
                                                      slow_parasite_clearance_time = 5))
 })
 
@@ -91,12 +91,12 @@ test_that('set_antimalarial_resistance() errors if drug index > than number of d
                                                      drug = 2,
                                                      timesteps = 1,
                                                      artemisinin_resistance = 0.4,
-                                                     partner_drug_resistance = 0.3,
-                                                     slow_parasite_clearance_prob = 0.5,
+                                                     partner_drug_resistance = 0,
+                                                     slow_parasite_clearance_prob = 0,
                                                      early_treatment_failure_prob = 0.6,
-                                                     late_clinical_failure_prob = 0.2,
-                                                     late_parasitological_prob = 0.3,
-                                                     reinfection_prob = 0.4))
+                                                     late_clinical_failure_prob = 0,
+                                                     late_parasitological_prob = 0,
+                                                     reinfection_prob = 0))
 })
 
 test_that('set_antimalarial_resistance() assigns parameters correctly despite order in which resistance parameters are specified', {
@@ -111,7 +111,7 @@ test_that('set_antimalarial_resistance() assigns parameters correctly despite or
                                             timesteps = 1,
                                             artemisinin_resistance = 0.5,
                                             partner_drug_resistance = 0,
-                                            slow_parasite_clearance_prob = 0.41,
+                                            slow_parasite_clearance_prob = 0,
                                             early_treatment_failure_prob = 0.2,
                                             late_clinical_failure_prob = 0,
                                             late_parasitological_prob = 0,
@@ -120,36 +120,36 @@ test_that('set_antimalarial_resistance() assigns parameters correctly despite or
   parameters <- set_antimalarial_resistance(parameters = parameters,
                                             drug = 3,
                                             timesteps = 1,
-                                            artemisinin_resistance = 0,
-                                            partner_drug_resistance = 0.43,
+                                            artemisinin_resistance = 0.43,
+                                            partner_drug_resistance = 0,
                                             slow_parasite_clearance_prob = 0,
                                             early_treatment_failure_prob = 0,
-                                            late_clinical_failure_prob = 0.01,
-                                            late_parasitological_prob = 0.42,
-                                            reinfection_prob = 0.89, 
+                                            late_clinical_failure_prob = 0,
+                                            late_parasitological_prob = 0,
+                                            reinfection_prob = 0, 
                                             slow_parasite_clearance_time = 10)
   parameters <- set_antimalarial_resistance(parameters = parameters,
                                             drug = 1,
                                             timesteps = 1,
                                             artemisinin_resistance = 0.27,
-                                            partner_drug_resistance = 0.61,
-                                            slow_parasite_clearance_prob = 0.23,
+                                            partner_drug_resistance = 0,
+                                            slow_parasite_clearance_prob = 0,
                                             early_treatment_failure_prob = 0.9,
-                                            late_clinical_failure_prob = 0.49,
-                                            late_parasitological_prob = 0.81,
-                                            reinfection_prob = 0.009, 
+                                            late_clinical_failure_prob = 0,
+                                            late_parasitological_prob = 0,
+                                            reinfection_prob = 0, 
                                             slow_parasite_clearance_time = 20)
   
   expect_identical(parameters$antimalarial_resistance, TRUE)
   expect_identical(unlist(parameters$antimalarial_resistance_drug), c(2, 3, 1))
   expect_identical(unlist(parameters$antimalarial_resistance_timesteps), rep(1, 3))
-  expect_identical(unlist(parameters$prop_artemisinin_resistant), c(0.5, 0, 0.27))
-  expect_identical(unlist(parameters$prop_partner_drug_resistant), c(0, 0.43, 0.61))
-  expect_identical(unlist(parameters$slow_parasite_clearance_prob), c(0.41, 0, 0.23))
+  expect_identical(unlist(parameters$prop_artemisinin_resistant), c(0.5, 0.43, 0.27))
+  expect_identical(unlist(parameters$prop_partner_drug_resistant), c(0, 0, 0))
+  expect_identical(unlist(parameters$slow_parasite_clearance_prob), c(0, 0, 0))
   expect_identical(unlist(parameters$early_treatment_failure_prob), c(0.2, 0, 0.9))
-  expect_identical(unlist(parameters$late_clinical_failure_prob), c(0, 0.01, 0.49))
-  expect_identical(unlist(parameters$late_parasitological_failure_prob), c(0, 0.42, 0.81))
-  expect_identical(unlist(parameters$reinfection_during_prophylaxis), c(0, 0.89, 0.009))
+  expect_identical(unlist(parameters$late_clinical_failure_prob), c(0, 0, 0))
+  expect_identical(unlist(parameters$late_parasitological_failure_prob), c(0, 0, 0))
+  expect_identical(unlist(parameters$reinfection_during_prophylaxis), c(0, 0, 0))
   expect_identical(unlist(parameters$dt_slow_parasite_clearance), c(5, 10, 20))
   
 })
@@ -168,12 +168,12 @@ test_that(desc = "set_antimalarial_resistance errors if length slow_parasite_cle
                                               drug = 1,
                                               timesteps = c(0, 10),
                                               artemisinin_resistance = c(0.4, 0.8),
-                                              partner_drug_resistance = c(0.23, 0.43),
-                                              slow_parasite_clearance_prob = c(0.2, 0.4),
+                                              partner_drug_resistance = c(0, 0),
+                                              slow_parasite_clearance_prob = c(0, 0),
                                               early_treatment_failure_prob = c(0, 0.45),
-                                              late_clinical_failure_prob = c(0.01, 0.01),
-                                              late_parasitological_prob = c(0.05, 0.06),
-                                              reinfection_prob = c(0.86, 0.86), 
+                                              late_clinical_failure_prob = c(0, 0),
+                                              late_parasitological_prob = c(0, 0),
+                                              reinfection_prob = c(0, 0), 
                                               slow_parasite_clearance_time = c(10 ,11)),
     "Error: length of slow_parasite_clearance_time not equal to 1")
 })
@@ -192,14 +192,99 @@ test_that(desc = "set_antimalarial_resistance errors if slow_parasite_clearance_
                                               drug = 1,
                                               timesteps = c(0, 10),
                                               artemisinin_resistance = c(0.4, 0.8),
-                                              partner_drug_resistance = c(0.23, 0.43),
-                                              slow_parasite_clearance_prob = c(0.2, 0.4),
+                                              partner_drug_resistance = c(0, 0),
+                                              slow_parasite_clearance_prob = c(0, 0),
                                               early_treatment_failure_prob = c(0, 0.45),
-                                              late_clinical_failure_prob = c(0.01, 0.01),
-                                              late_parasitological_prob = c(0.05, 0.06),
-                                              reinfection_prob = c(0.86, 0.86), 
+                                              late_clinical_failure_prob = c(0, 0),
+                                              late_parasitological_prob = c(0, 0),
+                                              reinfection_prob = c(0, 0), 
                                               slow_parasite_clearance_time = c(0)),
     "Error: slow_parasite_clearance_time is non-positive")
+})
+
+test_that("set_antimalarial_resistance() errors when users attempt to use undeveloped model features", {
+  
+  # Partner Drug Resistance
+  expect_error(get_parameters() |>
+                 set_drugs(drugs = list(SP_AQ_params)) |>
+                 set_clinical_treatment(drug = 1, timesteps = 1, coverages = 0.6) |>
+                 set_antimalarial_resistance(drug = 1, 
+                                             timesteps = c(1, 10), 
+                                             artemisinin_resistance = c(0.4, 0.5),
+                                             partner_drug_resistance = c(0, 0.5), 
+                                             slow_parasite_clearance_prob = c(0, 0), 
+                                             early_treatment_failure_prob = c(0.8, 0.8), 
+                                             late_clinical_failure_prob = c(0, 0), 
+                                             late_parasitological_prob = c(0, 0), 
+                                             reinfection_prob = c(0, 0), 
+                                             slow_parasite_clearance_time = 10),
+               "Parameters set for unimplemented feature - late clinical failure, late parasitological failure, or reinfection during prophylaxis")
+  
+  
+  # Slow Parasite Clearance
+  expect_error(get_parameters() |>
+                 set_drugs(drugs = list(SP_AQ_params)) |>
+                 set_clinical_treatment(drug = 1, timesteps = 1, coverages = 0.6) |>
+                 set_antimalarial_resistance(drug = 1, 
+                                             timesteps = c(1, 10), 
+                                             artemisinin_resistance = c(0.4, 0.5),
+                                             partner_drug_resistance = c(0, 0), 
+                                             slow_parasite_clearance_prob = c(0, 0.0001), 
+                                             early_treatment_failure_prob = c(0.8, 0.8), 
+                                             late_clinical_failure_prob = c(0, 0), 
+                                             late_parasitological_prob = c(0, 0), 
+                                             reinfection_prob = c(0, 0), 
+                                             slow_parasite_clearance_time = 10),
+               "Parameters set for unimplemented feature - late clinical failure, late parasitological failure, or reinfection during prophylaxis")
+  
+  # Late Clinical Failure
+  expect_error(get_parameters() |>
+                 set_drugs(drugs = list(SP_AQ_params)) |>
+                 set_clinical_treatment(drug = 1, timesteps = 1, coverages = 0.6) |>
+                 set_antimalarial_resistance(drug = 1, 
+                                             timesteps = c(1, 10), 
+                                             artemisinin_resistance = c(0.4, 0.5),
+                                             partner_drug_resistance = c(0, 0), 
+                                             slow_parasite_clearance_prob = c(0, 0), 
+                                             early_treatment_failure_prob = c(0.8, 0.8), 
+                                             late_clinical_failure_prob = c(0.6, 0.43), 
+                                             late_parasitological_prob = c(0, 0), 
+                                             reinfection_prob = c(0, 0), 
+                                             slow_parasite_clearance_time = 10),
+               "Parameters set for unimplemented feature - late clinical failure, late parasitological failure, or reinfection during prophylaxis")
+  
+  # Late Parasitological Failure
+  expect_error(get_parameters() |>
+                 set_drugs(drugs = list(SP_AQ_params)) |>
+                 set_clinical_treatment(drug = 1, timesteps = 1, coverages = 0.6) |>
+                 set_antimalarial_resistance(drug = 1, 
+                                             timesteps = c(1, 10), 
+                                             artemisinin_resistance = c(0.4, 0.5),
+                                             partner_drug_resistance = c(0, 0), 
+                                             slow_parasite_clearance_prob = c(0, 0), 
+                                             early_treatment_failure_prob = c(0.8, 0.8), 
+                                             late_clinical_failure_prob = c(0, 0), 
+                                             late_parasitological_prob = c(1, 0), 
+                                             reinfection_prob = c(0, 0), 
+                                             slow_parasite_clearance_time = 10),
+               "Parameters set for unimplemented feature - late clinical failure, late parasitological failure, or reinfection during prophylaxis")
+  
+  # Reinfection During Prophylaxis
+  expect_error(get_parameters() |>
+                 set_drugs(drugs = list(SP_AQ_params)) |>
+                 set_clinical_treatment(drug = 1, timesteps = 1, coverages = 0.6) |>
+                 set_antimalarial_resistance(drug = 1, 
+                                             timesteps = c(1, 10), 
+                                             artemisinin_resistance = c(0.4, 0.5),
+                                             partner_drug_resistance = c(0, 0), 
+                                             slow_parasite_clearance_prob = c(0, 0), 
+                                             early_treatment_failure_prob = c(0.8, 0.8), 
+                                             late_clinical_failure_prob = c(0, 0), 
+                                             late_parasitological_prob = c(0, 0), 
+                                             reinfection_prob = c(0.21, 0), 
+                                             slow_parasite_clearance_time = 10),
+               "Parameters set for unimplemented feature - late clinical failure, late parasitological failure, or reinfection during prophylaxis")
+  
 })
 
 test_that('get_antimalarial_resistance_parameters() correctly retrieves parameters when multiple drugs assigned', {
@@ -213,32 +298,32 @@ test_that('get_antimalarial_resistance_parameters() correctly retrieves paramete
       set_antimalarial_resistance(drug = 2,
                                   timesteps = c(0, 20),
                                   artemisinin_resistance = c(0.02, 0.2),
-                                  partner_drug_resistance = c(0.02, 0.2),
-                                  slow_parasite_clearance_prob = c(0.02, 0.2),
+                                  partner_drug_resistance = c(0, 0),
+                                  slow_parasite_clearance_prob = c(0, 0),
                                   early_treatment_failure_prob = c(0.02, 0.2),
-                                  late_clinical_failure_prob = c(0.02, 0.2),
-                                  late_parasitological_prob = c(0.02, 0.2),
-                                  reinfection_prob = c(0.02, 0.2), 
+                                  late_clinical_failure_prob = c(0, 0),
+                                  late_parasitological_prob = c(0, 0),
+                                  reinfection_prob = c(0, 0), 
                                   slow_parasite_clearance_time = 20) %>%
       set_antimalarial_resistance(drug = 1,
                                   timesteps = c(0, 10),
                                   artemisinin_resistance = c(0.01, 0.1),
-                                  partner_drug_resistance = c(0.01, 0.1),
-                                  slow_parasite_clearance_prob = c(0.01, 0.1),
+                                  partner_drug_resistance = c(0, 0),
+                                  slow_parasite_clearance_prob = c(0, 0),
                                   early_treatment_failure_prob = c(0.01, 0.1),
-                                  late_clinical_failure_prob = c(0.01, 0.1),
-                                  late_parasitological_prob = c(0.01, 0.1),
-                                  reinfection_prob = c(0.01, 0.1),
+                                  late_clinical_failure_prob = c(0, 0),
+                                  late_parasitological_prob = c(0, 0),
+                                  reinfection_prob = c(0, 0),
                                   slow_parasite_clearance_time = 10) %>%
       set_antimalarial_resistance(drug = 3,
                                   timesteps = c(0, 30),
                                   artemisinin_resistance = c(0.03, 0.3),
-                                  partner_drug_resistance = c(0.03, 0.3),
-                                  slow_parasite_clearance_prob = c(0.03, 0.3),
+                                  partner_drug_resistance = c(0, 0),
+                                  slow_parasite_clearance_prob = c(0, 0),
                                   early_treatment_failure_prob = c(0.03, 0.3),
-                                  late_clinical_failure_prob = c(0.03, 0.3),
-                                  late_parasitological_prob = c(0.03, 0.3),
-                                  reinfection_prob = c(0.03, 0.3),
+                                  late_clinical_failure_prob = c(0, 0),
+                                  late_parasitological_prob = c(0, 0),
+                                  reinfection_prob = c(0, 0),
                                   slow_parasite_clearance_time = 30) -> parameters
     
     drugs <- c(1, 3, 2, 1, 2, 3, 3, 3, 2, 1, 3, 1, 2, 3, 2)
@@ -250,12 +335,12 @@ test_that('get_antimalarial_resistance_parameters() correctly retrieves paramete
     
     expected_resistance_parameters <- list()
     expected_resistance_parameters$artemisinin_resistance_proportion <- c(0.1, 0.03, 0.2, 0.1, 0.2, 0.03, 0.03, 0.03, 0.2, 0.1, 0.03, 0.1, 0.2, 0.03, 0.2)
-    expected_resistance_parameters$partner_drug_resistance_proportion <- c(0.1, 0.03, 0.2, 0.1, 0.2, 0.03, 0.03, 0.03, 0.2, 0.1, 0.03, 0.1, 0.2, 0.03, 0.2)
-    expected_resistance_parameters$slow_parasite_clearance_probability <- c(0.1, 0.03, 0.2, 0.1, 0.2, 0.03, 0.03, 0.03, 0.2, 0.1, 0.03, 0.1, 0.2, 0.03, 0.2)
+    expected_resistance_parameters$partner_drug_resistance_proportion <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    expected_resistance_parameters$slow_parasite_clearance_probability <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     expected_resistance_parameters$early_treatment_failure_probability <- c(0.1, 0.03, 0.2, 0.1, 0.2, 0.03, 0.03, 0.03, 0.2, 0.1, 0.03, 0.1, 0.2, 0.03, 0.2)
-    expected_resistance_parameters$late_clinical_failure_probability <- c(0.1, 0.03, 0.2, 0.1, 0.2, 0.03, 0.03, 0.03, 0.2, 0.1, 0.03, 0.1, 0.2, 0.03, 0.2)
-    expected_resistance_parameters$late_parasitological_failure_probability <- c(0.1, 0.03, 0.2, 0.1, 0.2, 0.03, 0.03, 0.03, 0.2, 0.1, 0.03, 0.1, 0.2, 0.03, 0.2)
-    expected_resistance_parameters$reinfection_during_prophylaxis_probability <- c(0.1, 0.03, 0.2, 0.1, 0.2, 0.03, 0.03, 0.03, 0.2, 0.1, 0.03, 0.1, 0.2, 0.03, 0.2)
+    expected_resistance_parameters$late_clinical_failure_probability <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    expected_resistance_parameters$late_parasitological_failure_probability <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    expected_resistance_parameters$reinfection_during_prophylaxis_probability <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     expected_resistance_parameters$dt_slow_parasite_clearance <- c(10, 30, 20, 10, 20, 30, 30, 30, 20, 10, 30, 10, 20, 30, 20)
     
     expect_identical(resistance_parameters, expected = expected_resistance_parameters)
@@ -273,12 +358,12 @@ test_that('get_antimalarial_resistance_parameters() correctly retrieves paramete
       set_antimalarial_resistance(drug = 2,
                                   timesteps = c(0, 20),
                                   artemisinin_resistance = c(0.02, 0.2),
-                                  partner_drug_resistance = c(0.02, 0.2),
-                                  slow_parasite_clearance_prob = c(0.02, 0.2),
+                                  partner_drug_resistance = c(0, 0),
+                                  slow_parasite_clearance_prob = c(0, 0),
                                   early_treatment_failure_prob = c(0.02, 0.2),
-                                  late_clinical_failure_prob = c(0.02, 0.2),
-                                  late_parasitological_prob = c(0.02, 0.2),
-                                  reinfection_prob = c(0.02, 0.2), 
+                                  late_clinical_failure_prob = c(0, 0),
+                                  late_parasitological_prob = c(0, 0),
+                                  reinfection_prob = c(0, 0), 
                                   slow_parasite_clearance_time = 20) -> parameters
     
     drugs <- c(1, 3, 2, 1, 2, 3, 3, 3, 2, 1, 3, 1, 2, 3, 2)
@@ -290,12 +375,12 @@ test_that('get_antimalarial_resistance_parameters() correctly retrieves paramete
     
     expected_resistance_parameters <- list()
     expected_resistance_parameters$artemisinin_resistance_proportion <- c(0, 0, 0.2, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.2)
-    expected_resistance_parameters$partner_drug_resistance_proportion <- c(0, 0, 0.2, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.2)
-    expected_resistance_parameters$slow_parasite_clearance_probability <- c(0, 0, 0.2, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.2)
+    expected_resistance_parameters$partner_drug_resistance_proportion <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    expected_resistance_parameters$slow_parasite_clearance_probability <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     expected_resistance_parameters$early_treatment_failure_probability <- c(0, 0, 0.2, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.2)
-    expected_resistance_parameters$late_clinical_failure_probability <- c(0, 0, 0.2, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.2)
-    expected_resistance_parameters$late_parasitological_failure_probability <- c(0, 0, 0.2, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.2)
-    expected_resistance_parameters$reinfection_during_prophylaxis_probability <- c(0, 0, 0.2, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.2)
+    expected_resistance_parameters$late_clinical_failure_probability <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    expected_resistance_parameters$late_parasitological_failure_probability <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    expected_resistance_parameters$reinfection_during_prophylaxis_probability <- c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     expected_resistance_parameters$dt_slow_parasite_clearance <- c(5, 5, 20, 5, 20, 5, 5, 5, 20, 5, 5, 5, 20, 5, 20)
     
     expect_identical(resistance_parameters, expected = expected_resistance_parameters)


### PR DESCRIPTION
Following the suggestion in the antimalarial_resistance/etf pull request, I have added a check in the `set_antimalarial_resistance()` function to error when users attempt to give non-zero values to parameters relating to undeveloped features.

I have also added a test to the test-antimalarial-resistance.R file to ensure the check works as anticipated.

The documentation entries for the parameters in the `get_parameters()` (parameters.R) documentation have been modified to warn users that the parameters represent features under development.

I stopped short of adding a note in the vignette, but can add this if it is thought to be a good idea!