### PR TITLE
Age structured mean rendering

### DIFF
--- a/R/output_parameters.R
+++ b/R/output_parameters.R
@@ -10,7 +10,13 @@
 #' @param clinical_incidence age breaks for clinical incidence outputs (symptomatic); default = c(0, 1825)
 #' @param severe_incidence age breaks for severe incidence outputs (p.f only); default = NULL
 #' @param prevalence age breaks for clinical prevalence outputs (pcr and lm detectable infections); default = c(730, 3650)
-#' @param hypnozoite_prevalence age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
+#' @param n_hypnozoites age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
+#' @param ica age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
+#' @param icm age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
+#' @param id age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
+#' @param idm age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
+#' @param ib age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
+#' @param hypnozoites age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
 #' @export
 #'
 set_epi_outputs <- function(parameters,
@@ -20,18 +26,33 @@ set_epi_outputs <- function(parameters,
                             clinical_incidence = NULL,
                             severe_incidence = NULL,
                             prevalence = NULL,
-                            hypnozoite_prevalence = NULL
+                            n_hypnozoites = NULL,
+                            ica = NULL,
+                            icm = NULL,
+                            iva = NULL,
+                            ivm = NULL,
+                            id = NULL,
+                            idm = NULL,
+                            ib = NULL,
+                            hypnozoites = NULL
+
 ){
 
   if(parameters$parasite == "falciparum" & !is.null(patent_incidence)){message("Patent incidence will not be output for P. falciparum")}
-  if(parameters$parasite == "falciparum" & !is.null(hypnozoite_prevalence)){message("Hypnozoite prevalence will not be output for P. falciparum")}
-  if(parameters$parasite == "vivax" & !is.null(hypnozoite_prevalence)){message("Severe incidence will not be output for P. vivax")}
+  if(parameters$parasite == "falciparum" & !is.null(n_hypnozoites)){message("Number with hypnozoites will not be output for P. falciparum")}
+  if(parameters$parasite == "falciparum" & !is.null(idm)){message("IDM will not be output for P. falciparum")}
+  if(parameters$parasite == "falciparum" & !is.null(hypnozoites)){message("Hypnozoite prevalence will not be output for P. falciparum")}
+  if(parameters$parasite == "vivax" & !is.null(severe_incidence)){message("Severe incidence will not be output for P. vivax")}
+  if(parameters$parasite == "vivax" & !is.null(iva)){message("IV will not be output for P. vivax")}
+  if(parameters$parasite == "vivax" & !is.null(ivm)){message("IVM will not be output for P. vivax")}
+  if(parameters$parasite == "vivax" & !is.null(ib)){message("IB will not be output for P. vivax")}
 
   parent_formals <- names(formals())
   parent_formals <- parent_formals[which(parent_formals != "parameters")]
   outputs <- parent_formals[!unlist(lapply(parent_formals, function(x){is.null(get(x))}))]
 
   for (output in outputs) {
+    if(any(get(output) != sort(get(output)))){stop(paste0(output," inputs must increase"))}
     parameters[[paste0(output, "_rendering_min_ages")]] <- get(output)[-length(get(output))]
     parameters[[paste0(output, "_rendering_max_ages")]] <- get(output)[-1]-1
   }

--- a/R/output_parameters.R
+++ b/R/output_parameters.R
@@ -11,11 +11,13 @@
 #' @param severe_incidence age breaks for severe incidence outputs (p.f only); default = NULL
 #' @param prevalence age breaks for clinical prevalence outputs (pcr and lm detectable infections); default = c(730, 3650)
 #' @param n_hypnozoites age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
-#' @param ica age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
-#' @param icm age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
-#' @param id age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
-#' @param idm age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
-#' @param ib age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
+#' @param ica age breaks for acquired clinical immunity outputs; default = NULL
+#' @param icm age breaks for maternal clinical immunity outputs; default = NULL
+#' @param iva age breaks for acquired severe immunity outputs (p.f only); default = NULL
+#' @param ivm age breaks for maternal severe immunity outputs (p.f only); default = NULL
+#' @param id age breaks for immunity to detectability (p.f) or acquired antiparasite immunity outputs (p.v only); default = NULL
+#' @param idm age breaks for maternal antiparasite immunity outputs (p.v only); default = NULL
+#' @param ib age breaks for blood immunity outputs (p.f only); default = NULL
 #' @param hypnozoites age breaks for hypnozoite prevalence outputs (p.v only); default = NULL
 #' @export
 #'

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -168,8 +168,25 @@
 #' * prevalence_rendering_min_ages - the minimum ages for clinical prevalence
 #' outputs (pcr and lm detectable infections); default = 730
 #' * prevalence_rendering_max_ages - the corresponding max ages; default = 3650
-#' * hypnozoite_prevalence_rendering_min_ages - the minimum ages for hypnozoite prevalence outputs (p.v only); default = numeric(0)
-#' * hypnozoite_prevalence_rendering_max_ages - the corresponding max ages; default = numeric(0)
+#' * n_hypnozoites_rendering_min_ages - the minimum ages for number with hypnozoites outputs (p.v only); default = numeric(0)
+#' * n_hypnozoites_rendering_max_ages - the corresponding max ages; default = numeric(0)
+
+#' * ica_rendering_min_ages - the minimum ages for acquired clinical immunity outputs; default = numeric(0)
+#' * ica_rendering_max_ages - the corresponding max ages; default = numeric(0)
+#' * icm_rendering_min_ages - the minimum ages for maternal clinical immunity outputs; default = numeric(0)
+#' * icm_rendering_max_ages - the corresponding max ages; default = numeric(0)
+#' * iva_rendering_min_ages - the minimum ages for acquired severe immunity outputs (p.f only); default = numeric(0)
+#' * iva_rendering_max_ages - the corresponding max ages; default = numeric(0)
+#' * ivm_rendering_min_ages - the minimum ages for maternal severe immunity outputs (p.f only); default = numeric(0)
+#' * ivm_rendering_max_ages - the corresponding max ages; default = numeric(0)
+#' * id_rendering_min_ages - the minimum ages for detectability immunity (p.f) or acquired antiparasite immunity (p.v only) acquired severe immunity outputs (p.v only); default = numeric(0)
+#' * id_rendering_max_ages - the corresponding max ages; default = numeric(0)
+#' * idm_rendering_min_ages - the minimum ages for maternal antiparasite immunity outputs (p.v only); default = numeric(0)
+#' * idm_rendering_max_ages - the corresponding max ages; default = numeric(0)
+#' * ib_rendering_min_ages - the minimum ages for blood immunity outputs (p.f only); default = numeric(0)
+#' * ib_rendering_max_ages - the corresponding max ages; default = numeric(0)
+#' * hypnozoites_rendering_min_ages - the minimum ages average hypnozoites outputs (p.v only); default = numeric(0)
+#' * hypnozoites_rendering_max_ages - the corresponding max ages; default = numeric(0)
 #'
 #' mosquito life stage transitions:
 #'

--- a/R/processes.R
+++ b/R/processes.R
@@ -211,6 +211,12 @@ create_processes <- function(
         renderer,
         variables$hypnozoites,
         parameters
+      ),
+      create_hypnozoite_age_renderer_process(
+        variables$hypnozoites,
+        variables$birth,
+        parameters,
+        renderer
       )
     )
   }
@@ -239,8 +245,9 @@ create_processes <- function(
       parameters,
       renderer
     ),
-    create_hypnozoite_age_renderer_process(
-      variables$hypnozoites,
+    create_age_variable_mean_renderer_process(
+      imm_var_names[paste0(imm_var_names,"_rendering_min_ages") %in% names(parameters)],
+      variables[imm_var_names[paste0(imm_var_names,"_rendering_min_ages") %in% names(parameters)]],
       variables$birth,
       parameters,
       renderer

--- a/R/render.R
+++ b/R/render.R
@@ -145,6 +145,30 @@ create_variable_mean_renderer_process <- function(
   }
 }
 
+create_age_variable_mean_renderer_process <- function(
+    names,
+    variables,
+    birth,
+    parameters,
+    renderer
+) {
+  function(timestep) {
+    for (i in seq_along(variables)) {
+      for (j in seq_along(parameters[[paste0(names[[i]],"_rendering_min_ages")]])) {
+        lower <- parameters[[paste0(names[[i]],"_rendering_min_ages")]][[j]]
+        upper <- parameters[[paste0(names[[i]],"_rendering_max_ages")]][[j]]
+        in_age <- in_age_range(birth, timestep, lower, upper)
+        renderer$render(paste0('n_', lower, '_', upper), in_age$size(), timestep)
+        renderer$render(
+          paste0(names[[i]], '_mean_', lower, '_', upper),
+          mean(variables[[i]]$get_values(index = in_age)),
+          timestep
+        )
+      }
+    }
+  }
+}
+
 create_vector_count_renderer_individual <- function(
     mosquito_state,
     species,

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -181,8 +181,24 @@ outputs (p.f only); default = turned off
 \item prevalence_rendering_min_ages - the minimum ages for clinical prevalence
 outputs (pcr and lm detectable infections); default = 730
 \item prevalence_rendering_max_ages - the corresponding max ages; default = 3650
-\item hypnozoite_prevalence_rendering_min_ages - the minimum ages for hypnozoite prevalence outputs (p.v only); default = numeric(0)
-\item hypnozoite_prevalence_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item n_hypnozoites_rendering_min_ages - the minimum ages for number with hypnozoites outputs (p.v only); default = numeric(0)
+\item n_hypnozoites_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item ica_rendering_min_ages - the minimum ages for acquired clinical immunity outputs; default = numeric(0)
+\item ica_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item icm_rendering_min_ages - the minimum ages for maternal clinical immunity outputs; default = numeric(0)
+\item icm_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item iva_rendering_min_ages - the minimum ages for acquired severe immunity outputs (p.f only); default = numeric(0)
+\item iva_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item ivm_rendering_min_ages - the minimum ages for maternal severe immunity outputs (p.f only); default = numeric(0)
+\item ivm_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item id_rendering_min_ages - the minimum ages for detectability immunity (p.f) or acquired antiparasite immunity (p.v only) acquired severe immunity outputs (p.v only); default = numeric(0)
+\item id_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item idm_rendering_min_ages - the minimum ages for maternal antiparasite immunity outputs (p.v only); default = numeric(0)
+\item idm_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item ib_rendering_min_ages - the minimum ages for blood immunity outputs (p.f only); default = numeric(0)
+\item ib_rendering_max_ages - the corresponding max ages; default = numeric(0)
+\item hypnozoites_rendering_min_ages - the minimum ages average hypnozoites outputs (p.v only); default = numeric(0)
+\item hypnozoites_rendering_max_ages - the corresponding max ages; default = numeric(0)
 }
 
 mosquito life stage transitions:

--- a/man/set_epi_outputs.Rd
+++ b/man/set_epi_outputs.Rd
@@ -12,7 +12,15 @@ set_epi_outputs(
   clinical_incidence = NULL,
   severe_incidence = NULL,
   prevalence = NULL,
-  hypnozoite_prevalence = NULL
+  n_hypnozoites = NULL,
+  ica = NULL,
+  icm = NULL,
+  iva = NULL,
+  ivm = NULL,
+  id = NULL,
+  idm = NULL,
+  ib = NULL,
+  hypnozoites = NULL
 )
 }
 \arguments{
@@ -30,7 +38,19 @@ set_epi_outputs(
 
 \item{prevalence}{age breaks for clinical prevalence outputs (pcr and lm detectable infections); default = c(730, 3650)}
 
-\item{hypnozoite_prevalence}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+\item{n_hypnozoites}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+
+\item{ica}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+
+\item{icm}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+
+\item{id}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+
+\item{idm}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+
+\item{ib}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+
+\item{hypnozoites}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
 }
 \description{
 Parameterise age grouped output rendering

--- a/man/set_epi_outputs.Rd
+++ b/man/set_epi_outputs.Rd
@@ -40,15 +40,19 @@ set_epi_outputs(
 
 \item{n_hypnozoites}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
 
-\item{ica}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+\item{ica}{age breaks for acquired clinical immunity outputs; default = NULL}
 
-\item{icm}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+\item{icm}{age breaks for maternal clinical immunity outputs; default = NULL}
 
-\item{id}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+\item{iva}{age breaks for acquired severe immunity outputs (p.f only); default = NULL}
 
-\item{idm}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+\item{ivm}{age breaks for maternal severe immunity outputs (p.f only); default = NULL}
 
-\item{ib}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
+\item{id}{age breaks for immunity to detectability (p.f) or acquired antiparasite immunity outputs (p.v only); default = NULL}
+
+\item{idm}{age breaks for maternal antiparasite immunity outputs (p.v only); default = NULL}
+
+\item{ib}{age breaks for blood immunity outputs (p.f only); default = NULL}
 
 \item{hypnozoites}{age breaks for hypnozoite prevalence outputs (p.v only); default = NULL}
 }


### PR DESCRIPTION
I've extended the options for the set_epi_outputs function to include age-structured immunity outputs and age-structured hypnozoite prevalence outputs. Hopefully it won't slow things down too much, but if there's a more efficient way of doing this, I'm happy to take another look!