### PR TITLE
Update description of the dt parameter.

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -11,7 +11,7 @@
 #' fixed state transitions:
 #'
 #' * dd - the delay for humans to move from state D to A; default = 5
-#' * dt - the delay for humans to move from state Tr to Ph; default = 5
+#' * dt - the delay for humans to move from state Tr to S; default = 5
 #' * da - the delay for humans to move from state A to U; default = 195
 #' * du - the delay for humans to move from state U to S; default = 110
 #' * del - the delay for mosquitoes to move from state E to L; default = 6.64

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -13,7 +13,7 @@ The parameters are defined below.
 fixed state transitions:
 \itemize{
 \item dd - the delay for humans to move from state D to A; default = 5
-\item dt - the delay for humans to move from state Tr to Ph; default = 5
+\item dt - the delay for humans to move from state Tr to S; default = 5
 \item da - the delay for humans to move from state A to U; default = 195
 \item du - the delay for humans to move from state U to S; default = 110
 \item del - the delay for mosquitoes to move from state E to L; default = 6.64


### PR DESCRIPTION
The dt parameter was described as "the delay to move from state Tr to Ph", but the Ph (prophylaxis) state does not exist in the model. Instead the dt parameter is used to transition from Tr to S, in `R/processes.R`.

Looking at the commit history, there seems to have been a bit of back and forth around adding and removing the Tr and Ph states. The comment in question was introduced in mrc-ide/malariasimulation#30, after the prophylaxis state had already been removed and even at the time the parameter was already used as the transition rate from Tr to S.