### PR TITLE
calculate_eir function correction

### DIFF
--- a/R/biting_process.R
+++ b/R/biting_process.R
@@ -210,9 +210,7 @@ simulate_bites <- function(
 calculate_eir <- function(species, solvers, variables, parameters, timestep) {
   a <- human_blood_meal_rate(species, variables, parameters, timestep)
   infectious <- calculate_infectious(species, solvers, variables, parameters)
-  age <- get_age(variables$birth$get_values(), timestep)
-  psi <- unique_biting_rate(age, parameters)
-  infectious * a * mean(psi)
+  infectious * a
 }
 
 effective_biting_rates <- function(a, .pi, p_bitten) {

--- a/tests/testthat/test-biology.R
+++ b/tests/testthat/test-biology.R
@@ -16,17 +16,11 @@ test_that('total_M and EIR functions are consistent with equilibrium EIR', {
     vector_models <- parameterise_mosquito_models(parameters, 1)
     solvers <- parameterise_solvers(vector_models, parameters)
     estimated_eir <- calculate_eir(1, solvers, variables, parameters, 0)
-    age <- get_age(variables$birth$get_values(), 0)
-    psi <- unique_biting_rate(age, parameters)
-    omega <- mean(psi)
-    mean(estimated_eir) / omega / population * 365
+    mean(estimated_eir) / population * 365
   })
 
   expect_equal(
-    actual_EIR * 0.766,
-    # 0.766 is the population average psi under an exponential pop distribution
-    # There's possibly a better way of calculating this, depending on what exactly
-    # we're testing here, e.g., we could remove lines 19-21 and omega from line 22
+    actual_EIR,
     expected_EIR,
     tolerance = 1e-2
   )
@@ -47,17 +41,11 @@ test_that('total_M and EIR functions are consistent with equilibrium EIR (with h
     vector_models <- parameterise_mosquito_models(parameters, 1)
     solvers <- parameterise_solvers(vector_models, parameters)
     estimated_eir <- calculate_eir(1, solvers, variables, parameters, 0)
-    age <- get_age(variables$birth$get_values(), 0)
-    psi <- unique_biting_rate(age, parameters)
-    omega <- mean(psi)
-    mean(estimated_eir) / omega / population * 365
+    mean(estimated_eir) / population * 365
   })
 
   expect_equal(
-    actual_EIR * 0.766,
-    # 0.766 is the population average psi under an exponential pop distribution
-    # There's possibly a better way of calculating this, depending on what exactly
-    # we're testing here, e.g., we could remove lines 49-51 and omega from line 52
+    actual_EIR,
     expected_EIR,
     tolerance = 1e-2
   )

--- a/tests/testthat/test-biology.R
+++ b/tests/testthat/test-biology.R
@@ -23,7 +23,10 @@ test_that('total_M and EIR functions are consistent with equilibrium EIR', {
   })
 
   expect_equal(
-    actual_EIR,
+    actual_EIR * 0.766,
+    # 0.766 is the population average psi under an exponential pop distribution
+    # There's possibly a better way of calculating this, depending on what exactly
+    # we're testing here, e.g., we could remove lines 19-21 and omega from line 22
     expected_EIR,
     tolerance = 1e-2
   )
@@ -51,7 +54,10 @@ test_that('total_M and EIR functions are consistent with equilibrium EIR (with h
   })
 
   expect_equal(
-    actual_EIR,
+    actual_EIR * 0.766,
+    # 0.766 is the population average psi under an exponential pop distribution
+    # There's possibly a better way of calculating this, depending on what exactly
+    # we're testing here, e.g., we could remove lines 49-51 and omega from line 52
     expected_EIR,
     tolerance = 1e-2
   )


### PR DESCRIPTION
The function that calculates the initial EIR doesn't appear to be quite right. I don't think it needs to be multiplied by psi. When these values are drawn in lines 135-140 of biting_process.R they get multiplied by psi in line 144. That means we're effectively multiplying these values by psi^2. I think we can correct this by adjusting the calculation thusly.

The two tests at the end would then need adjusting (one way or another) to reflect this change - which could probably use some improving.

I've drawn a couple of plots to show the difference this is trying to correct and that it doesn't change too much:
[eir_calculation_comp_timesteps.pdf](https://github.com/mrc-ide/malariasimulation/files/15178558/eir_calculation_comp_timesteps.pdf)
[eir_calculation_comp.pdf](https://github.com/mrc-ide/malariasimulation/files/15178561/eir_calculation_comp.pdf)
