### PR TITLE
Older age groups (older than equilibrium age object) are not correctl…

### DIFF
--- a/R/variables.R
+++ b/R/variables.R
@@ -321,8 +321,6 @@ initial_immunity <- function(
   ) {
   if (!is.null(eq)) {
     age <- age / 365
-    # older ages must be assigned within the equilibrium age bounds
-    age[age>=max(eq[[1]][, 'age'])] <- max(eq[[1]][, 'age'])-0.01
     return(vnapply(
       seq_along(age),
       function(i) {
@@ -340,8 +338,6 @@ initial_state <- function(parameters, age, groups, eq, states) {
   if (!is.null(eq)) {
     eq_states <- c('S', 'D', 'A', 'U', 'T')
     age <- age / 365
-    # older ages must be assigned within the equilibrium age bounds
-    age[age>=max(eq[[1]][, 'age'])] <- max(eq[[1]][, 'age'])-0.01
     return(vcapply(
       seq_along(age),
       function(i) {
@@ -399,9 +395,10 @@ calculate_initial_ages <- function(parameters) {
   n_pop <- get_human_population(parameters, 0)
   # check if we've set up a custom demography
   if (!parameters$custom_demography) {
-    return(round(rexp(
+    return(round(rtexp(
       n_pop,
-      rate = 1 / parameters$average_age
+      1 / parameters$average_age,
+      max(EQUILIBRIUM_AGES)*365
     )))
   }
 

--- a/R/variables.R
+++ b/R/variables.R
@@ -321,6 +321,8 @@ initial_immunity <- function(
   ) {
   if (!is.null(eq)) {
     age <- age / 365
+    # older ages must be assigned within the equilibrium age bounds
+    age[age>=max(eq[[1]][, 'age'])] <- max(eq[[1]][, 'age'])-0.01
     return(vnapply(
       seq_along(age),
       function(i) {
@@ -338,6 +340,8 @@ initial_state <- function(parameters, age, groups, eq, states) {
   if (!is.null(eq)) {
     eq_states <- c('S', 'D', 'A', 'U', 'T')
     age <- age / 365
+    # older ages must be assigned within the equilibrium age bounds
+    age[age>=max(eq[[1]][, 'age'])] <- max(eq[[1]][, 'age'])-0.01
     return(vcapply(
       seq_along(age),
       function(i) {

--- a/tests/testthat/test-demography.R
+++ b/tests/testthat/test-demography.R
@@ -1,13 +1,14 @@
-test_that('calculate_initial_ages defaults to an exponential distribution', {
+test_that('calculate_initial_ages defaults to a truncated exponential distribution', {
   parameters <- get_parameters(list(human_population = 4))
   mock_exp <- mockery::mock(seq(4))
-  mockery::stub(calculate_initial_ages, 'rexp', mock_exp)
+  mockery::stub(calculate_initial_ages, 'rtexp', mock_exp)
   ages <- calculate_initial_ages(parameters)
   mockery::expect_args(
     mock_exp,
     1,
     parameters$human_population,
-    1 / parameters$average_age
+    1 / parameters$average_age,
+    max(EQUILIBRIUM_AGES)*365
   )
 })
 


### PR DESCRIPTION
I noticed that when individuals are older than the max equilbrium solution age group, the human states and immunity assignments doesn't know how to interpret it. It then assigns states and immunity using the youngest age group, which underestimates infection and acquired immunity, while overestimating maternal immunity in this age group (and explains why we often see an initial peak in maternal immunity). I've tried to correct this. Plots show the average over 10 simulations at the first timestep.

State plots (fewer S in age_correction (older)):
![image](https://github.com/mrc-ide/malariasimulation/assets/73181123/552b33ce-22f1-4c7f-a6ec-0b93a2aa2961)

Immunity plots (slightly higher in acquired imm, lower in maternal):
![image](https://github.com/mrc-ide/malariasimulation/assets/73181123/d7814e9e-7987-4ad7-b46f-21cb8585f299)

And Immunities through time (averaged over 10 repetitions, EIR = 50):
![image](https://github.com/mrc-ide/malariasimulation/assets/73181123/b470c812-dc18-41be-abf1-c8d6f44f2e46)
