### PR TITLE
Example correlation diagnostics:

### DIFF
--- a/R/correlation.R
+++ b/R/correlation.R
@@ -331,3 +331,31 @@ rcondmvnorm <- function(n, mean, sigma, given, dependent.ind, given.ind) {
     samples + cond_mu
   }
 }
+
+used_intervention <- function(variable, timestep, window) {
+  variable$get_index_of(set=-1)$not()$and(
+    variable$get_index_of(a=timestep - window, b=timestep)
+  )
+}
+
+create_combined_intervention_rendering_process <- function(
+  int_1,
+  variable_1,
+  int_2,
+  variable_2,
+  window,
+  renderer
+) {
+  name <- paste0('n_combined_', int_1, '_', int_2)
+  renderer$set_default(name, 0)
+  function (timestep) {
+    n <- used_intervention(variable_1, timestep, window)$and(
+      used_intervention(variable_2, timestep, window)
+    )$size()
+    renderer$render(
+      name,
+      n,
+      timestep
+    )
+  }
+}

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -191,10 +191,10 @@ CorrelationParameters <- R6::R6Class(
 #' @param parameters model parameters
 #' @export
 #' @examples
-#' 
+#'
 #' # get the default model parameters
 #' parameters <- get_parameters()
-#' 
+#'
 #' # Set some vaccination strategy
 #' parameters <- set_mass_pev(
 #'   parameters,
@@ -208,7 +208,7 @@ CorrelationParameters <- R6::R6Class(
 #'   booster_coverage = numeric(0),
 #'   booster_profile = NULL
 #' )
-#' 
+#'
 #' # Set some smc strategy
 #' parameters <- set_drugs(parameters, list(SP_AQ_params))
 #' parameters <- set_smc(
@@ -219,14 +219,14 @@ CorrelationParameters <- R6::R6Class(
 #'   min_age = 100,
 #'   max_age = 1000
 #' )
-#' 
+#'
 #' # Correlate the vaccination and smc targets
 #' correlations <- get_correlation_parameters(parameters)
 #' correlations$inter_intervention_rho('pev', 'smc', 1)
-#' 
+#'
 #' # Correlate the rounds of smc
 #' correlations$inter_round_rho('smc', 1)
-#' 
+#'
 #' # You can now pass the correlation parameters to the run_simulation function
 get_correlation_parameters <- function(parameters) {
   # Find a list of enabled interventions

--- a/R/events.R
+++ b/R/events.R
@@ -123,7 +123,8 @@ attach_event_listeners <- function(
         variables,
         events,
         parameters,
-        correlations
+        correlations,
+        renderer
       )
     )
     attach_pev_dose_listeners(

--- a/R/mda_processes.R
+++ b/R/mda_processes.R
@@ -33,7 +33,7 @@ create_mda_listeners <- function(
     target <- in_age[sample_intervention(in_age, int_name, coverage, correlations)]
 
     renderer$render(paste0('n_', int_name, '_treated'), length(target), timestep)
-    
+
     successful_treatments <- bernoulli(
       length(target),
       parameters$drug_efficacy[[drug]]
@@ -75,6 +75,7 @@ create_mda_listeners <- function(
       # Update drug
       variables$drug$queue_update(drug, to_move)
       variables$drug_time$queue_update(timestep, to_move)
+      variables[[paste0(int_name, '_time')]]$queue_update(timestep, to_move)
     }
   }
 }

--- a/R/mortality_processes.R
+++ b/R/mortality_processes.R
@@ -113,6 +113,9 @@ reset_target <- function(variables, events, target, state, parameters, timestep)
     variables$pev_profile$queue_update(-1, target)
     variables$tbv_vaccinated$queue_update(-1, target)
 
+    # spraying
+    variables$spray_time$queue_update(-1, target)
+
     # onwards infectiousness
     variables$infectivity$queue_update(0, target)
 

--- a/R/mortality_processes.R
+++ b/R/mortality_processes.R
@@ -104,6 +104,8 @@ reset_target <- function(variables, events, target, state, parameters, timestep)
     # treatment
     variables$drug$queue_update(0, target)
     variables$drug_time$queue_update(-1, target)
+    variables$smc_time$queue_update(-1, target)
+    variables$mda_time$queue_update(-1, target)
 
     # vaccination
     variables$last_pev_timestep$queue_update(-1, target)
@@ -113,7 +115,7 @@ reset_target <- function(variables, events, target, state, parameters, timestep)
 
     # onwards infectiousness
     variables$infectivity$queue_update(0, target)
-    
+
     # treated compartment residence time:
     if(!is.null(variables$dt)) {
       variables$dt$queue_update(parameters$dt, target)

--- a/R/pev.R
+++ b/R/pev.R
@@ -25,7 +25,7 @@ create_epi_pev_process <- function(
     if(coverage == 0){
       return()
     }
-    
+
     to_vaccinate <- variables$birth$get_index_of(
       set = timestep - parameters$pev_epi_age
     )
@@ -77,6 +77,7 @@ create_epi_pev_process <- function(
 #' @param events a list of events in the model
 #' @param parameters the model parameters
 #' @param correlations correlation parameters
+#' @param renderer the model renderer object
 #' @noRd
 create_mass_pev_listener <- function(
   variables,
@@ -86,6 +87,7 @@ create_mass_pev_listener <- function(
   renderer
   ) {
   renderer$set_default('n_new_vaccinations', 0)
+  renderer$set_default('n_pev_last_year', 0)
   function(timestep) {
     in_age_group <- individual::Bitset$new(parameters$human_population)
     for (i in seq_along(parameters$mass_pev_min_ages)) {
@@ -111,7 +113,7 @@ create_mass_pev_listener <- function(
     } else {
       target <- target$to_vector()
     }
-    
+
     time_index = which(parameters$mass_pev_timesteps == timestep)
     target <- target[
       sample_intervention(
@@ -129,6 +131,7 @@ create_mass_pev_listener <- function(
     )$size()
 
     renderer$render('n_new_vaccinations', n_new_vaccinations, timestep)
+    renderer$render('n_pev_last_year', used_intervention(variables$last_pev_timestep, timestep, 365)$size(), timestep)
 
     # Update the latest vaccination time
     variables$last_pev_timestep$queue_update(timestep, target)

--- a/R/pev.R
+++ b/R/pev.R
@@ -82,8 +82,10 @@ create_mass_pev_listener <- function(
   variables,
   events,
   parameters,
-  correlations
+  correlations,
+  renderer
   ) {
+  renderer$set_default('n_new_vaccinations', 0)
   function(timestep) {
     in_age_group <- individual::Bitset$new(parameters$human_population)
     for (i in seq_along(parameters$mass_pev_min_ages)) {
@@ -119,6 +121,14 @@ create_mass_pev_listener <- function(
         correlations
       )
     ]
+
+    n_new_vaccinations <- variables$last_pev_timestep$get_index_of(
+      set=-1
+    )$not()$and(
+      individual::Bitset$new(parameters$human_population)$insert(target)
+    )$size()
+
+    renderer$render('n_new_vaccinations', n_new_vaccinations, timestep)
 
     # Update the latest vaccination time
     variables$last_pev_timestep$queue_update(timestep, target)

--- a/R/processes.R
+++ b/R/processes.R
@@ -267,7 +267,21 @@ create_processes <- function(
   # Mortality step
   processes <- c(
     processes,
-    create_mortality_process(variables, events, renderer, parameters))
+    create_mortality_process(variables, events, renderer, parameters)
+  )
+
+  # Combined interventions
+  processes <- c(
+    processes,
+    create_combined_intervention_rendering_process(
+      'pev',
+      variables$last_pev_timestep,
+      'bednets',
+      variables$net_time,
+      365,
+      renderer
+    )
+  )
 
   processes
 }

--- a/R/processes.R
+++ b/R/processes.R
@@ -250,8 +250,12 @@ create_processes <- function(
   if (parameters$spraying) {
     processes <- c(
       processes,
-      indoor_spraying(variables$spray_time, parameters, correlations),
-      spray_renderer(variables$spray_time, renderer)
+      indoor_spraying(
+        variables$spray_time,
+        renderer,
+        parameters,
+        correlations
+        )
     )
   }
 
@@ -271,7 +275,9 @@ create_processes <- function(
     create_mortality_process(variables, events, renderer, parameters)
   )
 
+  # ======================
   # Combined interventions
+  # ======================
   # PEV & bednets
   if (parameters$pev & parameters$bednets) {
     processes <- c(

--- a/R/processes.R
+++ b/R/processes.R
@@ -272,83 +272,96 @@ create_processes <- function(
   )
 
   # Combined interventions
-  # pev - bednets
-  processes <- c(
-    processes,
-    create_combined_intervention_rendering_process(
-      'pev',
-      variables$last_pev_timestep,
-      'bednets',
-      variables$net_time,
-      365,
-      renderer
+  # PEV & bednets
+  if (parameters$pev & parameters$bednets) {
+    processes <- c(
+      processes,
+      create_combined_intervention_rendering_process(
+        'pev',
+        variables$last_eff_pev_timestep,
+        'bednets',
+        variables$net_time,
+        365,
+        renderer
+      )
     )
-  )
+  }
 
-  # smc - bednets
-  processes <- c(
-    processes,
-    create_combined_intervention_rendering_process(
-      'smc',
-      variables$drug_time,
-      'bednets',
-      variables$net_time,
-      365,
-      renderer
+  # SMC & bednets
+  if (parameters$smc & parameters$bednets) {
+    processes <- c(
+      processes,
+      create_combined_intervention_rendering_process(
+        'smc',
+        variables$smc_time,
+        'bednets',
+        variables$net_time,
+        365,
+        renderer
+      )
     )
-  )
+  }
 
-  # pev - smc
-  processes <- c(
-    processes,
-    create_combined_intervention_rendering_process(
-      'pev',
-      variables$last_pev_timestep,
-      'smc',
-      variables$drug_time,
-      365,
-      renderer
+  # PEV & SMC
+  if (parameters$pev & parameters$smc) {
+    processes <- c(
+      processes,
+      create_combined_intervention_rendering_process(
+        'pev',
+        variables$last_eff_pev_timestep,
+        'smc',
+        variables$smc_time,
+        365,
+        renderer
+      )
     )
-  )
+  }
 
-  # irs - bednet
-  processes <- c(
-    processes,
-    create_combined_intervention_rendering_process(
-      'spraying',
-      variables$spray_time,
-      'bednets',
-      variables$net_time,
-      365,
-      renderer
+  # Spraying & bednets
+  if (parameters$spraying & parameters$bednets) {
+    processes <- c(
+      processes,
+      create_combined_intervention_rendering_process(
+        'spraying',
+        variables$spray_time,
+        'bednets',
+        variables$net_time,
+        365,
+        renderer
+      )
     )
-  )
+  }
 
-  # irs - smc
-  processes <- c(
-    processes,
-    create_combined_intervention_rendering_process(
-      'spraying',
-      variables$spray_time,
-      'smc',
-      variables$drug_time,
-      365,
-      renderer
+  # Spraying & SMC
+  if (parameters$spraying & parameters$smc) {
+    processes <- c(
+      processes,
+      create_combined_intervention_rendering_process(
+        'spraying',
+        variables$spray_time,
+        'smc',
+        variables$smc_time,
+        365,
+        renderer
+      )
     )
-  )
+  }
 
-  # irs - pev
-  processes <- c(
-    processes,
-    create_combined_intervention_rendering_process(
-      'spraying',
-      variables$spray_time,
-      'pev',
-      variables$last_pev_timestep,
-      365,
-      renderer
+  # Spraying & PEV
+  if (parameters$spraying & parameters$pev) {
+    processes <- c(
+      processes,
+      create_combined_intervention_rendering_process(
+        'spraying',
+        variables$spray_time,
+        'pev',
+        variables$last_eff_pev_timestep,
+        365,
+        renderer
+      )
     )
-  )
+  }
+
 
   processes
 }

--- a/R/processes.R
+++ b/R/processes.R
@@ -143,7 +143,7 @@ create_processes <- function(
   )
 
   # =========
-  # RTS,S EPI
+  # PEV EPI
   # =========
   if (!is.null(parameters$pev_epi_coverage)) {
     processes <- c(
@@ -239,6 +239,7 @@ create_processes <- function(
       processes,
       distribute_nets(
         variables,
+        renderer,
         events$throw_away_net,
         parameters,
         correlations

--- a/R/processes.R
+++ b/R/processes.R
@@ -30,7 +30,7 @@ create_processes <- function(
     correlations,
     lagged_eir,
     lagged_infectivity,
-    timesteps, 
+    timesteps,
     mixing = 1,
     mixing_index = 1
 ) {
@@ -105,22 +105,22 @@ create_processes <- function(
       0
     )
   )
-  
+
   # =======================
   # Antimalarial Resistance
   # =======================
   # Add an a new process which governs the transition from Tr to S when
   # antimalarial resistance is simulated. The rate of transition switches
   # from a parameter to a variable when antimalarial resistance == TRUE.
-  
+
   # Assign the dt input to a separate object with the default single parameter value:
   dt_input <- parameters$dt
-  
-  # If antimalarial resistance is switched on, assign dt variable values to the 
+
+  # If antimalarial resistance is switched on, assign dt variable values to the
   if(parameters$antimalarial_resistance) {
     dt_input <- variables$dt
   }
-  
+
   # Create the progression process for Tr --> S specifying dt_input as the rate:
   processes <- c(
     processes,
@@ -250,7 +250,8 @@ create_processes <- function(
   if (parameters$spraying) {
     processes <- c(
       processes,
-      indoor_spraying(variables$spray_time, parameters, correlations)
+      indoor_spraying(variables$spray_time, parameters, correlations),
+      spray_renderer(variables$spray_time, renderer)
     )
   }
 
@@ -271,6 +272,7 @@ create_processes <- function(
   )
 
   # Combined interventions
+  # pev - bednets
   processes <- c(
     processes,
     create_combined_intervention_rendering_process(
@@ -278,6 +280,71 @@ create_processes <- function(
       variables$last_pev_timestep,
       'bednets',
       variables$net_time,
+      365,
+      renderer
+    )
+  )
+
+  # smc - bednets
+  processes <- c(
+    processes,
+    create_combined_intervention_rendering_process(
+      'smc',
+      variables$drug_time,
+      'bednets',
+      variables$net_time,
+      365,
+      renderer
+    )
+  )
+
+  # pev - smc
+  processes <- c(
+    processes,
+    create_combined_intervention_rendering_process(
+      'pev',
+      variables$last_pev_timestep,
+      'smc',
+      variables$drug_time,
+      365,
+      renderer
+    )
+  )
+
+  # irs - bednet
+  processes <- c(
+    processes,
+    create_combined_intervention_rendering_process(
+      'spraying',
+      variables$spray_time,
+      'bednets',
+      variables$net_time,
+      365,
+      renderer
+    )
+  )
+
+  # irs - smc
+  processes <- c(
+    processes,
+    create_combined_intervention_rendering_process(
+      'spraying',
+      variables$spray_time,
+      'smc',
+      variables$drug_time,
+      365,
+      renderer
+    )
+  )
+
+  # irs - pev
+  processes <- c(
+    processes,
+    create_combined_intervention_rendering_process(
+      'spraying',
+      variables$spray_time,
+      'pev',
+      variables$last_pev_timestep,
       365,
       renderer
     )

--- a/R/variables.R
+++ b/R/variables.R
@@ -1,4 +1,4 @@
-#' @title Define model variables 
+#' @title Define model variables
 #' @description
 #' create_variables creates the human and mosquito variables for
 #' the model. Variables are used to track real data for each individual over
@@ -32,11 +32,13 @@
 #' * infectivity - The onward infectiousness to mosquitos
 #' * drug - The last prescribed drug
 #' * drug_time - The timestep of the last drug
+#' * smc_time - The timestep of the last smc drug
+#' * mda_time - The timestep of the last mda drug
 #'
 #' Antimalarial resistance variables are:
 #' * dt - the delay for humans to move from state Tr to state S
 #'
-#' Mosquito variables are: 
+#' Mosquito variables are:
 #' * mosquito_state - the state of the mosquito, a category Sm|Pm|Im|NonExistent
 #' * species - the species of mosquito, this is a category gamb|fun|arab
 #'
@@ -193,6 +195,8 @@ create_variables <- function(parameters) {
 
   drug <- individual::IntegerVariable$new(rep(0, size))
   drug_time <- individual::IntegerVariable$new(rep(-1, size))
+  smc_time <- individual::IntegerVariable$new(rep(-1, size))
+  mda_time <- individual::IntegerVariable$new(rep(-1, size))
 
   last_pev_timestep <- individual::IntegerVariable$new(rep(-1, size))
   last_eff_pev_timestep <- individual::IntegerVariable$new(rep(-1, size))
@@ -222,6 +226,8 @@ create_variables <- function(parameters) {
     infectivity = infectivity,
     drug = drug,
     drug_time = drug_time,
+    smc_time = smc_time,
+    mda_time = mda_time,
     last_pev_timestep = last_pev_timestep,
     last_eff_pev_timestep = last_eff_pev_timestep,
     pev_profile = pev_profile,
@@ -229,7 +235,7 @@ create_variables <- function(parameters) {
     net_time = net_time,
     spray_time = spray_time
   )
-  
+
   # Add variables for antimalarial resistance state residency times (dt)
   if(parameters$antimalarial_resistance) {
     dt <- individual::DoubleVariable$new(rep(parameters$dt, size))

--- a/R/vector_control.R
+++ b/R/vector_control.R
@@ -196,3 +196,13 @@ net_usage_renderer <- function(net_time, renderer) {
     )
   }
 }
+
+spray_renderer <- function(spray_time, renderer) {
+  function(t) {
+    renderer$render(
+      'n_spray_retain',
+      spray_time$get_index_of(-1)$not(TRUE)$size(),
+      t
+    )
+  }
+}

--- a/R/vector_control.R
+++ b/R/vector_control.R
@@ -102,13 +102,13 @@ prob_bitten <- function(
 #' `get_correlation_parameters`
 #'
 #' @param spray_time the variable for the time of spraying
-#' @param renderer items to render
+#' @param renderer the model renderer object
 #' @param parameters the model parameters
 #' @param correlations correlation parameters
 #' @noRd
 indoor_spraying <- function(spray_time, renderer, parameters, correlations) {
-  renderer$set_default("n_spray", 0)
-  renderer$set_default("spray_last_year", 0)
+  renderer$set_default('n_spray', 0)
+  renderer$set_default('n_spray_last_year', 0)
   function(timestep) {
     matches <- timestep == parameters$spraying_timesteps
     if (any(matches)) {
@@ -119,9 +119,9 @@ indoor_spraying <- function(spray_time, renderer, parameters, correlations) {
         correlations
       ))
       spray_time$queue_update(timestep, target)
-      renderer$render("n_spray", length(target), timestep)
+      renderer$render('n_spray', length(target), timestep)
     }
-    renderer$render("spray_last_year", used_intervention(spray_time, timestep, 365)$size(), timestep)
+    renderer$render('n_spray_last_year', used_intervention(spray_time, timestep, 365)$size(), timestep)
   }
 }
 
@@ -132,11 +132,14 @@ indoor_spraying <- function(spray_time, renderer, parameters, correlations) {
 #' `get_correlation_parameters`
 #'
 #' @param variables list of variables in the model
+#' @param renderer the model renderer object
 #' @param throw_away_net an event to trigger when the net will be removed
 #' @param parameters the model parameters
 #' @param correlations correlation parameters
 #' @noRd
-distribute_nets <- function(variables, throw_away_net, parameters, correlations) {
+distribute_nets <- function(variables, renderer, throw_away_net, parameters, correlations) {
+  renderer$set_default('n_net', 0)
+  renderer$set_default('n_net_last_year', 0)
   function(timestep) {
     matches <- timestep == parameters$bednet_timesteps
     if (any(matches)) {
@@ -152,7 +155,9 @@ distribute_nets <- function(variables, throw_away_net, parameters, correlations)
         target,
         log_uniform(length(target), parameters$bednet_retention)
       )
+      renderer$render('n_net', length(target), timestep)
     }
+    renderer$render('n_net_last_year', used_intervention(variables$net_time, timestep, 365)$size(), timestep)
   }
 }
 

--- a/R/vector_control.R
+++ b/R/vector_control.R
@@ -102,10 +102,13 @@ prob_bitten <- function(
 #' `get_correlation_parameters`
 #'
 #' @param spray_time the variable for the time of spraying
+#' @param renderer items to render
 #' @param parameters the model parameters
 #' @param correlations correlation parameters
 #' @noRd
-indoor_spraying <- function(spray_time, parameters, correlations) {
+indoor_spraying <- function(spray_time, renderer, parameters, correlations) {
+  renderer$set_default("n_spray", 0)
+  renderer$set_default("spray_last_year", 0)
   function(timestep) {
     matches <- timestep == parameters$spraying_timesteps
     if (any(matches)) {
@@ -116,9 +119,12 @@ indoor_spraying <- function(spray_time, parameters, correlations) {
         correlations
       ))
       spray_time$queue_update(timestep, target)
+      renderer$render("n_spray", length(target), timestep)
     }
+    renderer$render("spray_last_year", used_intervention(spray_time, timestep, 365)$size(), timestep)
   }
 }
+
 
 #' @title Distribute nets
 #' @description distributes nets to individuals according to the strategy
@@ -192,16 +198,6 @@ net_usage_renderer <- function(net_time, renderer) {
     renderer$render(
       'n_use_net',
       net_time$get_index_of(-1)$not(TRUE)$size(),
-      t
-    )
-  }
-}
-
-spray_renderer <- function(spray_time, renderer) {
-  function(t) {
-    renderer$render(
-      'n_spray_retain',
-      spray_time$get_index_of(-1)$not(TRUE)$size(),
       t
     )
   }


### PR DESCRIPTION
I've made a test script which outputs some diagnostics for the cases you mentioned. Feel free to copy and paste/adapt to diagnose what you need.

Once you have something that might be generally useful, we could turn this into a PR to merge into dev :)

Here's an example of use:

```r

library(malariasimulation)

month <- 30
year <- 365

# =========================================================
# testing that pev targets different people for inter round
# =========================================================

params <- get_parameters(list(
  human_population = 10000
))

params <- set_mass_pev(
  params,
  profile = rtss_profile,
  timesteps = c(5, 10),
  coverages = c(.5, .5),
  min_wait = 0,
  min_ages = 5 * month,
  max_ages = 10 * year,
  booster_spacing = c(1),
  booster_coverage = matrix(0., nrow=2), 
  booster_profile = list(rtss_booster_profile)
)

set.seed(123)

correlations <- get_correlation_parameters(params)

correlations$inter_round_rho('pev', 0)

output <- run_simulation(
  timesteps = 100,
  parameters = params,
  correlations = correlations
)

set.seed(123)

correlations <- get_correlation_parameters(params)

correlations$inter_round_rho('pev', 1)

output_2 <- run_simulation(
  timesteps = 100,
  parameters = params,
  correlations = correlations
)

print(output$n_new_vaccinations)
print(output_2$n_new_vaccinations)

# ===========================================
# testing that bednets and pev can be negatively correlated
# ===========================================

params <- get_parameters(list(
  human_population = 10000
))

params <- set_bednets(
  params,
  c(5, 10),
  coverages = c(.5, .5),
  retention = 5 * 365,
  dn0 = matrix(c(.533, .533), nrow = 2, ncol = 1),
  rn = matrix(c(.56, .56), nrow = 2, ncol = 1),
  rnm = matrix(c(.24, .24), nrow = 2, ncol = 1),
  gamman = rep(2.64 * 365, 2)
)

params <- set_mass_pev(
  params,
  profile = rtss_profile,
  timesteps = c(5, 10),
  coverages = c(.5, .5),
  min_wait = 0,
  min_ages = 5 * month,
  max_ages = 10 * year,
  booster_spacing = c(1),
  booster_coverage = matrix(0., nrow=2), 
  booster_profile = list(rtss_booster_profile)
)

set.seed(123)

correlations <- get_correlation_parameters(params)

correlations$inter_round_rho('pev', 1)
correlations$inter_round_rho('bednets', 1)
correlations$inter_intervention_rho('pev', 'bednets', 1.)

output <- run_simulation(
  timesteps = 100,
  parameters = params,
  correlations = correlations
)

set.seed(123)

correlations <- get_correlation_parameters(params)

correlations$inter_round_rho('pev', 1)
correlations$inter_round_rho('bednets', 1)
correlations$inter_intervention_rho('pev', 'bednets', -1.)

output_2 <- run_simulation(
  timesteps = 100,
  parameters = params,
  correlations = correlations
)

print(output$n_combined_pev_bednets)
print(output_2$n_combined_pev_bednets)
```

The outputs all look good!

```sh
  [1]   0   0   0   0   0   0   0   0   0 926   0   0   0   0   0   0   0   0
 [19]   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
 [37]   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
 [55]   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
 [73]   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
 [91]   0   0   0   0   0   0   0   0   0   0
  [1]    0    0    0    0    0    0    0    0    0 1789    0    0    0    0    0
 [16]    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
 [31]    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
 [46]    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
 [61]    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
 [76]    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
 [91]    0    0    0    0    0    0    0    0    0    0
  [1]    0    0    0    0    0 1830 1830 1830 1830 1827 1833 1833 1832 1832 1830
 [16] 1826 1824 1823 1823 1820 1820 1820 1819 1817 1815 1814 1812 1811 1811 1811
 [31] 1808 1806 1804 1802 1800 1798 1798 1796 1796 1794 1793 1792 1790 1788 1786
 [46] 1783 1782 1781 1778 1778 1778 1776 1775 1772 1772 1770 1769 1768 1767 1766
 [61] 1765 1765 1764 1762 1762 1762 1761 1760 1758 1758 1756 1755 1754 1753 1751
 [76] 1751 1749 1747 1746 1745 1742 1742 1741 1740 1740 1739 1739 1737 1737 1736
 [91] 1734 1734 1732 1730 1730 1729 1726 1725 1724 1722
  [1] 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 [38] 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 [75] 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
```

Changes to malariasimulation:

 * Some utility functions for outputting combined intervention counts
 * Some outputs for diagnosing inter round correlation issues