### PR TITLE
Depend on dqrng from CRAN again.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,15 +69,13 @@ LazyData: true
 Remotes:
   mrc-ide/malariaEquilibrium,
   mrc-ide/individual
-Additional_repositories:
-  https://mrc-ide.r-universe.dev
 Imports:
     individual (>= 0.1.16),
     malariaEquilibrium (>= 1.0.1),
     Rcpp,
     statmod,
     MASS,
-    dqrng (>= 0.3.2.2),
+    dqrng (>= 0.4),
     sitmo,
     BH,
     R6,

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -60,7 +60,7 @@ void Random::prop_sample_bucket(
 
     // all probabilities are the same
     if (heavy == n) {
-        for (auto i = 0; i < size; ++i) {
+        for (size_t i = 0; i < size; ++i) {
             *result = (*rng)((uint64_t)n);
             ++result;
         }
@@ -121,9 +121,9 @@ void Random::prop_sample_bucket(
     }
 
     // sample
-    for (auto i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i) {
         size_t bucket = (*rng)((uint64_t)n);
-        double acceptance = dqrng::uniform01((*rng)());
+        double acceptance = rng->uniform01();
         *result = (acceptance < dividing_probs[bucket]) ? bucket :
             alternative_index[bucket];
         ++result;


### PR DESCRIPTION
dqrng just released a new version, which means we can stop relying on the mrc-ide r-universe as an additional repository.