### PR TITLE
Allow p.v subpatent infections

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -37,10 +37,10 @@
 #' * da - the delay for humans to move from state A to U; default = 195
 #' * du - the delay for humans to move from state U to S (p.f only); default = 110
 #'
-#' duration of pcr detectable infection: du (p.v only):
+#' duration of pcr detectable infections: du (p.v only):
 #'
-#' * dpcr_max - Maximum duration of subpatent infection: default = 53.69
-#' * dpcr_min - Minimum duration of subpatent infection: default = 10
+#' * dpcr_max - Maximum duration of PCR-detectable infections: default = 53.69
+#' * dpcr_min - Minimum duration of PCR-detectable infections: default = 10
 #' * kpcr - Shape parameter: default = 4.021
 #' * apcr50 - Scale parameter: default = 9.8
 #' 
@@ -112,7 +112,7 @@
 #' * id0 - scale parameter; default = 1.577533
 #' * kd - shape parameter; default = 0.476614
 #'
-#' probability of patent infection due to anti-parasite immunity (p.v only):
+#' probability of light-microscopy detectable infections due to anti-parasite immunity (p.v only):
 #'
 #' * philm_max - maximum probability due to no immunity; default = 0.9329
 #' * philm_min - maximum reduction due to immunity; default = 0.0131
@@ -141,7 +141,7 @@
 #' * cd - infectivity of clinically diseased humans towards mosquitoes; default = 0.068
 #' * ca - infectivity of asymptomatic humans towards mosquitoes (p.v only); default = 0.1
 #' * gamma1 - parameter for infectivity of asymptomatic humans; default = 1.82425
-#' * cu - infectivity of sub-patent infection; default = 0.0062
+#' * cu - infectivity of subpatent infection; default = 0.0062
 #' * ct - infectivity of treated infection; default = 0.021896
 #'
 #' mosquito fixed state transitions (including mortality):
@@ -344,7 +344,7 @@ get_parameters <- function(overrides = list(), parasite = "falciparum") {
     # maternal immunity parameters
     # probability of pre-erythrocytic infection/blood immunity
     # probability of asymptomatic detection (p.f only)
-    # probability of patent infection (due to anti-parasite immunity, p.v only)
+    # probability of light-microscopy detectable infection (due to anti-parasite immunity, p.v only)
     # probability of clinical infection
     # probability of severe infection (p.f only)
     # infectivity towards mosquitos

--- a/R/processes.R
+++ b/R/processes.R
@@ -47,7 +47,7 @@ create_processes <- function(
     immunity_process = create_exponential_decay_process(variables$ica,
                                                         parameters$rc)
   )
-
+  
   if(parameters$parasite == "falciparum"){
     processes <- c(
       processes,
@@ -61,14 +61,17 @@ create_processes <- function(
       immunity_process = create_exponential_decay_process(variables$iva,
                                                           parameters$rva),
       # Immunity to detectability
-      immunity_process = create_exponential_decay_process(variables$id, parameters$rid)
+      immunity_process = create_exponential_decay_process(variables$id, 
+                                                          parameters$rid)
     )
   } else if (parameters$parasite == "vivax"){
     processes <- c(
       processes,
       # Anti-parasite immunity
-      immunity_process = create_exponential_decay_process(variables$iam, parameters$rm),
-      immunity_process = create_exponential_decay_process(variables$iaa, parameters$ra)
+      immunity_process = create_exponential_decay_process(variables$iam, 
+                                                          parameters$rm),
+      immunity_process = create_exponential_decay_process(variables$iaa, 
+                                                          parameters$ra)
     )
   }
 

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -38,10 +38,10 @@ human fixed state transitions:
 \item du - the delay for humans to move from state U to S (p.f only); default = 110
 }
 
-duration of pcr detectable infection: du (p.v only):
+duration of pcr detectable infections: du (p.v only):
 \itemize{
-\item dpcr_max - Maximum duration of subpatent infection: default = 53.69
-\item dpcr_min - Minimum duration of subpatent infection: default = 10
+\item dpcr_max - Maximum duration of PCR-detectable infections: default = 53.69
+\item dpcr_min - Minimum duration of PCR-detectable infections: default = 10
 \item kpcr - Shape parameter: default = 4.021
 \item apcr50 - Scale parameter: default = 9.8
 }
@@ -124,7 +124,7 @@ probability of detection by light-microscopy when asymptomatic (p.f only):
 \item kd - shape parameter; default = 0.476614
 }
 
-probability of patent infection due to anti-parasite immunity (p.v only):
+probability of light-microscopy detectable infections due to anti-parasite immunity (p.v only):
 \itemize{
 \item philm_max - maximum probability due to no immunity; default = 0.9329
 \item philm_min - maximum reduction due to immunity; default = 0.0131
@@ -156,7 +156,7 @@ infectivity towards mosquitoes:
 \item cd - infectivity of clinically diseased humans towards mosquitoes; default = 0.068
 \item ca - infectivity of asymptomatic humans towards mosquitoes (p.v only); default = 0.1
 \item gamma1 - parameter for infectivity of asymptomatic humans; default = 1.82425
-\item cu - infectivity of sub-patent infection; default = 0.0062
+\item cu - infectivity of subpatent infection; default = 0.0062
 \item ct - infectivity of treated infection; default = 0.021896
 }
 

--- a/vignettes/Plasmodium_vivax.Rmd
+++ b/vignettes/Plasmodium_vivax.Rmd
@@ -53,17 +53,17 @@ The *P. falciparum* model has five human disease compartments: susceptible (S), 
 
 The *P. vivax* model follows a similar structure to the *P. falciparum* model, and also has five human disease compartments. However, the human disease states modeled explicitly focus on parasite density and detectability, such that we have: susceptible (S), clinical disease (D), **light-microscopy detectable infection (A)**, **PCR detectable infection (U)**, and treated (Tr).
 
+### New Infections
+
+Newly infected individuals in the  *P. falciparum* model can move into either the clinically diseased or asymptomatic infection compartment. In addition to these compartments, the *P. vivax* model allows infection to the PCR-detectable compartment (U), where the assignment of light-miscroscopy detectable infections and PCR-detectable infections is mediated by anti-parasite immunity.
+
 ### Immunity
 
 The *P. falciparum* model tracks four kinds of immunity: immunity to blood stage infection (IB), clinical disease (acquired and maternal, ICA and ICM), to severe disease (acquired and maternal, IVA and IVM), and to detectability (ID).
 
 The *P. vivax* model tracks two kinds of immunity: immunity to clinical infection (acquired and maternal, ICA and ICM) and anti-parasite immunity (acquired and maternal, IAA and IAM). We do not track immunity to blood stage infections, severe immunity or immunity to detectability.
 
-### Anti-parasite immunity
-
-Anti-parasite immunity has effects in two places. The first is in the separation of PCR-detectable infections from LM-detectable infections (where greater immunity reduces the change of an infection with higher parasitaemia). The second is in the calculation of a PCR-detectable infection (where greater immunity results in a shorter duration before recovery).
-
-The *P. falciparum* model does not model infections to the sub-patent compartment (U) and has a constant sub-patent infection duration (`du = 110`).
+Anti-parasite immunity has effects in two places. The first is in the separation of PCR-detectable infections from LM-detectable infections (where greater immunity reduces the change of an infection with higher parasitaemia). The second is in the calculation of a PCR-detectable infection (where greater immunity results in a shorter duration before recovery). The *P. falciparum* model does not model infections to the sub-patent compartment (U) and has a constant sub-patent infection duration (`du = 110`).
 
 ### Infectivity of LM-detectable infections
 


### PR DESCRIPTION
p.v allows subpatent infections to occur, so we now calculate patent subpatent infections, render these and schedule them.