### PR TITLE
Assign names to all processes.

### DIFF
--- a/tests/testthat/test-processes.R
+++ b/tests/testthat/test-processes.R
@@ -5,12 +5,12 @@ test_that("exponential_decay_process works as expected", {
   v <- individual::DoubleVariable$new(c(0,0.5,1,2,4,10))
   p <- create_exponential_decay_process(v, rate)
 
-  individual:::execute_any_process(p, 1)
+  individual:::execute_process(p, 1)
   v$.update()
 
   expect_equal(v$get_values(), c(0, 0.25, 0.5, 1, 2, 5))
 
-  individual:::execute_any_process(p, 2)
+  individual:::execute_process(p, 2)
   v$.update()
 
   expect_equal(v$get_values(), c(0, 0.125, 0.25, 0.5, 1, 2.5))

--- a/tests/testthat/test-resume.R
+++ b/tests/testthat/test-resume.R
@@ -239,7 +239,7 @@ test_that("Correlations can be set when resuming with new interventions", {
       renderer$render("total_tbv_and_mda", tbv$copy()$and(mda)$size(), t)
       renderer$render("total_tbv_or_mda", tbv$copy()$or(mda)$size(), t)
     }
-    c(create_processes(renderer, variables, events, parameters, ...), p)
+    c(create_processes(renderer, variables, events, parameters, ...), p=p)
   }
 
   mockery::stub(run_resumable_simulation, 'create_processes', create_processes_stub)


### PR DESCRIPTION
Thanks to [individual#198], processes in the simulation can now be named. This has no effect on the behaviour of the simulation but helps in debugging and profiling by labelling the call frames with the given names.

While at it, I've fixed a typo in the name of the prevalence renderer.

[individual#198]: https://github.com/mrc-ide/individual/pull/198