### PR TITLE
Correcting default average_age parameter

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -30,7 +30,7 @@
 #'
 #' * human_population - the initial number of humans to model; default = 100
 #' * average_age - the average age of humans (in timesteps), this is only used
-#' if custom_demography is FALSE; default = 7663
+#' if custom_demography is FALSE; default = 7665
 #' * custom_demography - population demography given; default = FALSE
 #'
 #' initial immunity values:
@@ -281,7 +281,7 @@ get_parameters <- function(overrides = list()) {
     du    = 110,
     # human demography parameters
     human_population = 100,
-    average_age = 7663,
+    average_age = 7665,
     custom_demography = FALSE,
     # initial immunities
     init_ica = 0,

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -34,7 +34,7 @@ human demography parameters:
 \itemize{
 \item human_population - the initial number of humans to model; default = 100
 \item average_age - the average age of humans (in timesteps), this is only used
-if custom_demography is FALSE; default = 7663
+if custom_demography is FALSE; default = 7665
 \item custom_demography - population demography given; default = FALSE
 }
 


### PR DESCRIPTION
Default average age is currently 7663. The deterministic model average age is 7665, which is divisible by 365 (7665/365=21) and makes more sense to me.