### PR TITLE
Add a range check to bitset_index.

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -32,6 +32,11 @@ std::vector<size_t> bitset_index_cpp(
     Rcpp::XPtr<individual_index_t> a,
     Rcpp::XPtr<individual_index_t> b
     ) {
+    if (a->max_size() != b->max_size()) {
+        Rcpp::stop("Incompatible bitmap sizes, %d vs %d",
+                   a->max_size(), b->max_size());
+    }
+
     auto values = std::vector<size_t>();
     auto i = 1u;
     for (const auto& v : *a) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -21,3 +21,23 @@ test_that('time_cached calls again for a different timestep', {
   expect_equal(cached_fn(timestep = 2), 43)
   mockery::expect_called(fn, 2)
 })
+
+test_that("bitset_index works", {
+  a <- individual::Bitset$new(10)$insert(c(3,5,7,9))
+  b <- individual::Bitset$new(10)$insert(c(2,4,5,8,9))
+  expect_equal(bitset_index(a, b), c(2,4))
+
+  a <- individual::Bitset$new(10)
+  b <- individual::Bitset$new(10)$insert(c(2,4,5,8,9))
+  expect_equal(length(bitset_index(a, b)), 0)
+
+  a <- individual::Bitset$new(10)$insert(c(3,5,7,9))
+  b <- individual::Bitset$new(10)
+  expect_equal(length(bitset_index(a, b)), 0)
+})
+
+test_that("bitset_index errors if size does not match", {
+  a <- individual::Bitset$new(10)$insert(c(3,5,7,9))
+  b <- individual::Bitset$new(20)$insert(c(2,4,5,8,9))
+  expect_error(bitset_index(a, b), "Incompatible bitmap sizes")
+})


### PR DESCRIPTION
The function assumes the two bitsets are the same size, but was never checking for it. If the user passed in a second bitset that is smaller than the first, it could lead to an out-of-bounds access on the underlying std::vector.