### PR TITLE
recovery_rates variable has been renamed as (disease) progression_rates.

### DIFF
--- a/R/disease_progression.R
+++ b/R/disease_progression.R
@@ -1,34 +1,34 @@
-#' @title Calculate recovery rates
-#' @description Calculates recovery rates for each individual in the population
+#' @title Calculate disease progression rates
+#' @description Calculates disease progression rates for each individual in the population
 #' for storage in competing hazards object and subsequent resolution
 #'
 #' @param variables the available human variables
-#' @param recovery_outcome competing hazards object for recovery rates
+#' @param progression_outcome competing hazards object for disease progression rates
 #' @noRd
-create_recovery_rates_process <- function(
+create_progression_rates_process <- function(
   variables,
-  recovery_outcome
+  progression_outcome
 ) {
   function(timestep){
     target <- variables$state$get_index_of("S")$not()
-    recovery_outcome$set_rates(
+    progression_outcome$set_rates(
       target,
-      variables$recovery_rates$get_values(target))
+      variables$progression_rates$get_values(target))
   }
 }
 
 
-#' @title Disease progression outcomes (recovery)
+#' @title Disease progression outcomes
 #' @description Following resolution of competing hazards, update state and
 #' infectivity of sampled individuals
 #'
 #' @param timestep the current timestep
-#' @param target the sampled recovering individuals
+#' @param target the sampled progressing individuals
 #' @param variables the available human variables
 #' @param parameters model parameters
-#' @param renderer competing hazards object for recovery rates
+#' @param renderer competing hazards object for disease progression rates
 #' @noRd
-recovery_outcome_process <- function(
+progression_outcome_process <- function(
     timestep,
     target,
     variables,
@@ -48,7 +48,7 @@ recovery_outcome_process <- function(
     "U",
     variables$infectivity,
     parameters$cu,
-    variables$recovery_rates,
+    variables$progression_rates,
     1/parameters$du,
     variables$state$get_index_of("A")$and(target)
   )
@@ -58,7 +58,7 @@ recovery_outcome_process <- function(
     "S",
     variables$infectivity,
     0,
-    variables$recovery_rates,
+    variables$progression_rates,
     0,
     variables$state$get_index_of(c("U","Tr"))$and(target)
   )
@@ -73,19 +73,21 @@ recovery_outcome_process <- function(
 #' @param to_state the destination disease state
 #' @param infectivity the handle for the infectivity variable
 #' @param new_infectivity the new infectivity of the progressed individuals
+#' @param progression_rates the handle for the progression_rates variable
+#' @param new_progression the new disease progression rate of the progressed individuals
 #' @noRd
 update_infection <- function(
     state,
     to_state,
     infectivity,
     new_infectivity,
-    recovery_rates,
-    new_recovery_rate,
+    progression_rates,
+    new_progression_rate,
     to_move
 ) {
   state$queue_update(to_state, to_move)
   infectivity$queue_update(new_infectivity, to_move)
-  recovery_rates$queue_update(new_recovery_rate, to_move)
+  progression_rates$queue_update(new_progression_rate, to_move)
 }
 
 #' @title Modelling the progression to asymptomatic disease
@@ -115,7 +117,7 @@ update_to_asymptomatic_infection <- function(
       new_infectivity,
       to_move
     )
-    variables$recovery_rates$queue_update(
+    variables$progression_rates$queue_update(
       1/parameters$da,
       to_move
     )

--- a/R/human_infection.R
+++ b/R/human_infection.R
@@ -397,6 +397,7 @@ calculate_treated <- function(
 #' @param drugs drug index
 #' @param timestep the current timestep
 #' @param renderer simulation renderer
+#' @param int_name the intervention name to use for rendering, use "" for frontline treatment
 #' @noRd
 calculate_successful_treatments <- function(
     parameters,

--- a/R/mda_processes.R
+++ b/R/mda_processes.R
@@ -49,7 +49,7 @@ create_mda_listeners <- function(
     target <- in_age[sample_intervention(in_age, int_name, coverage, correlations)]
     
     renderer$render(paste0('n_', int_name, '_treated'), length(target), timestep)
-    treated <- bitset_at(individual::Bitset$new(parameters$human_population)$not(), target)
+    treated <- individual::Bitset$new(parameters$human_population)$insert(target)
     
     to_move <- calculate_successful_treatments(
       parameters,
@@ -73,7 +73,7 @@ create_mda_listeners <- function(
 
 #' @title Update individuals during MDA/PMC
 #' @description Updates individuals disease states, infectivity, dt and drug variables
-#' @param target bitset for individuals who have been successfully treated
+#' @param target a list containing the successfully treated, the drug used and resistance parameters
 #' @param variables the variables available in the model
 #' @param parameters the model parameters
 #' @param timestep the current timestep
@@ -101,7 +101,9 @@ update_mass_drug_admin <- function(
     to_treated <- clinical$or(asymptomatic$and(detectable))$and(target$successfully_treated)
     
     if(parameters$antimalarial_resistance) {
-      dt_update_vector <- target$dt_spc_combined[target$successfully_treated$to_vector() %in% to_treated$to_vector()]
+      dt_update_vector <- target$dt_spc_combined[
+        target$successfully_treated$copy()$and(to_treated)$to_vector()
+      ]
     } else {
       dt_update_vector <- parameters$dt
     }

--- a/R/mda_processes.R
+++ b/R/mda_processes.R
@@ -12,70 +12,128 @@
 #' @description will create a listener for administering each round of drugs
 #' @noRd
 create_mda_listeners <- function(
-  variables,
-  drug,
-  timesteps,
-  coverages,
-  min_ages,
-  max_ages,
-  correlations,
-  int_name,
-  parameters,
-  renderer
-  ) {
+    variables,
+    drug,
+    timesteps,
+    coverages,
+    min_ages,
+    max_ages,
+    correlations,
+    int_name,
+    parameters,
+    renderer
+) {
+  
   renderer$set_default(paste0('n_', int_name, '_treated'), 0)
+  renderer$set_default(paste0('n_', int_name, '_drug_efficacy_failures'), 0)
+  renderer$set_default(paste0('n_', int_name, '_successfully_treated'), 0)
+  
+  if(parameters$antimalarial_resistance){
+    renderer$set_default(paste0('n_', int_name, '_early_treatment_failure'), 0)
+    renderer$set_default(paste0('n_', int_name, '_slow_parasite_clearance'), 0)
+  }
+  
   function(timestep) {
     time_index = which(timesteps == timestep)
-    coverage <- coverages[[time_index]]
-    age <- get_age(variables$birth$get_values(), timestep)
-
-    in_age <- which((age > min_ages[[time_index]]) & (age < max_ages[[time_index]]))
-    target <- in_age[sample_intervention(in_age, int_name, coverage, correlations)]
-
-    renderer$render(paste0('n_', int_name, '_treated'), length(target), timestep)
-    
-    successful_treatments <- bernoulli(
-      length(target),
-      parameters$drug_efficacy[[drug]]
-    )
-    to_move <- individual::Bitset$new(parameters$human_population)
-    to_move$insert(target[successful_treatments])
-
-    if (to_move$size() > 0) {
-      # Move detectable
-      clinical <- variables$state$get_index_of('D')
-      asymptomatic <- variables$state$get_index_of('A')
-      detectable <- calculate_asymptomatic_detectable(
-        variables$state,
-        variables$birth,
-        variables$id,
-        parameters,
-        timestep
-      )
-      to_treat <- clinical$or(asymptomatic$and(detectable))
-      variables$state$queue_update(
-        'Tr',
-        to_treat$copy()$and(to_move)
-      )
-
-      # Move everyone else
-      other <- to_move$copy()$and(to_treat$not(TRUE))
-      if (other$size() > 0) {
-        variables$state$queue_update('S', other)
-      }
-
-      # Update infectivity
-      variables$infectivity$queue_update(
-        variables$infectivity$get_values(
-          to_move
-        ) * parameters$drug_rel_c[[drug]],
-        to_move
-      )
-
-      # Update drug
-      variables$drug$queue_update(drug, to_move)
-      variables$drug_time$queue_update(timestep, to_move)
+    if(time_index == 0){
+      return()
     }
+    coverage <- coverages[[time_index]]
+    if(coverage == 0){
+      return()
+    }
+    in_age <- variables$birth$get_index_of(
+      a = timestep - max_ages[[time_index]],
+      b = timestep - min_ages[[time_index]]
+    )$to_vector()
+    target <- in_age[sample_intervention(in_age, int_name, coverage, correlations)]
+    
+    renderer$render(paste0('n_', int_name, '_treated'), length(target), timestep)
+    treated <- bitset_at(individual::Bitset$new(parameters$human_population)$not(), target)
+    
+    to_move <- calculate_successful_treatments(
+      parameters,
+      treated,
+      rep(drug, treated$size()),
+      timestep,
+      renderer,
+      paste0(int_name,"_")
+      )
+    
+    update_mass_drug_admin(
+      to_move,
+      variables,
+      parameters,
+      timestep,
+      drug
+    )
+    
+  }
+}
+
+#' @title Update individuals during MDA/PMC
+#' @description Updates individuals disease states, infectivity, dt and drug variables
+#' @param target bitset for individuals who have been successfully treated
+#' @param variables the variables available in the model
+#' @param parameters the model parameters
+#' @param timestep the current timestep
+#' @param drug the drug to administer
+#' @noRd
+update_mass_drug_admin <- function(
+    target,
+    variables,
+    parameters,
+    timestep,
+    drug
+){
+  
+  if (target$successfully_treated$size() > 0) {
+    # Move clinical and detectable asymptomatic into treated
+    clinical <- variables$state$get_index_of('D')
+    asymptomatic <- variables$state$get_index_of('A')
+    detectable <- calculate_asymptomatic_detectable(
+      variables$state,
+      variables$birth,
+      variables$id,
+      parameters,
+      timestep
+    )
+    to_treated <- clinical$or(asymptomatic$and(detectable))$and(target$successfully_treated)
+    
+    if(parameters$antimalarial_resistance) {
+      dt_update_vector <- target$dt_spc_combined[target$successfully_treated$to_vector() %in% to_treated$to_vector()]
+    } else {
+      dt_update_vector <- parameters$dt
+    }
+    
+    update_infection(
+      variables$state,
+      'Tr',
+      variables$infectivity,
+      variables$infectivity$get_values(to_treated) * parameters$drug_rel_c[[drug]],
+      variables$progression_rates,
+      1/dt_update_vector,
+      to_treated
+    )
+    
+    # Move everyone else (susceptible, subpatent, non-detected asymptomatic and treated) to susceptible
+    other <- target$successfully_treated$copy()$and(to_treated$not(TRUE))
+    if (other$size() > 0) {
+      update_infection(
+        variables$state,
+        "S",
+        variables$infectivity,
+        0,
+        variables$progression_rates,
+        0,
+        other
+      )
+    }
+    
+    # Update drug
+    variables$drug$queue_update(drug, target$successfully_treated)
+    variables$drug_time$queue_update(timestep, target$successfully_treated)
+    
   }
 }
 
@@ -96,7 +154,7 @@ calculate_asymptomatic_detectable <- function(
     immunity,
     parameters,
     timestep
-  ) {
+) {
   asymptomatic <- state$get_index_of('A')
   prob <- probability_of_detection(
     get_age(birth$get_values(asymptomatic), timestep),

--- a/R/mortality_processes.R
+++ b/R/mortality_processes.R
@@ -113,7 +113,7 @@ reset_target <- function(variables, events, target, state, parameters, timestep)
 
     # onwards infectiousness
     variables$infectivity$queue_update(0, target)
-    variables$recovery_rates$queue_update(0, target)
+    variables$progression_rates$queue_update(0, target)
     
     # zeta and zeta group and vector controls survive rebirth
   }

--- a/R/pmc.R
+++ b/R/pmc.R
@@ -46,7 +46,7 @@ create_pmc_process <- function(
     target <- in_age[sample_intervention(in_age, 'pmc', coverage, correlations)]
     
     renderer$render('n_pmc_treated', length(target), timestep)
-    treated <- bitset_at(individual::Bitset$new(parameters$human_population)$not(), target)
+    treated <- individual::Bitset$new(parameters$human_population)$insert(target)
     
     to_move <- calculate_successful_treatments(
       parameters,

--- a/R/pmc.R
+++ b/R/pmc.R
@@ -23,54 +23,46 @@ create_pmc_process <- function(
     drug
 ){
   renderer$set_default('n_pmc_treated', 0)
+  renderer$set_default(paste0('n_pmc_drug_efficacy_failures'), 0)
+  renderer$set_default(paste0('n_pmc_successfully_treated'), 0)
+  
+  if(parameters$antimalarial_resistance){
+    renderer$set_default(paste0('n_pmc_early_treatment_failure'), 0)
+    renderer$set_default(paste0('n_pmc_slow_parasite_clearance'), 0)
+  }
+  
   function(timestep) {
-    timestep_index <- match_timestep(ts = timesteps, t = timestep)
-    if(timestep_index == 0){
+    time_index <- match_timestep(ts = timesteps, t = timestep)
+    if(time_index == 0){
       return()
     }
-    coverage <- coverages[timestep_index]
+    coverage <- coverages[time_index]
     if(coverage == 0){
       return()
     }
-    
-    age <- get_age(variables$birth$get_values(), timestep)
-    
-    in_age <- which(age %in% parameters$pmc_ages)
+    in_age <- variables$birth$get_index_of(
+      timesteps[time_index] - parameters$pmc_ages
+    )$to_vector()
     target <- in_age[sample_intervention(in_age, 'pmc', coverage, correlations)]
     
     renderer$render('n_pmc_treated', length(target), timestep)
+    treated <- bitset_at(individual::Bitset$new(parameters$human_population)$not(), target)
     
-    successful_treatments <- bernoulli(
-      length(target),
-      parameters$drug_efficacy[[drug]]
+    to_move <- calculate_successful_treatments(
+      parameters,
+      treated,
+      rep(drug, treated$size()),
+      timestep,
+      renderer,
+      "pmc_")
+    
+    update_mass_drug_admin(
+      to_move,
+      variables,
+      parameters,
+      timestep,
+      drug
     )
-    to_move <- individual::Bitset$new(parameters$human_population)
-    to_move$insert(target[successful_treatments])
     
-    if (to_move$size() > 0) {
-      # Move Diseased
-      diseased <- variables$state$get_index_of(c('D', 'A'))$and(to_move)
-      if (diseased$size() > 0) {
-        variables$state$queue_update('Tr', diseased)
-      }
-      
-      # Move everyone else
-      other <- to_move$copy()$and(diseased$not(TRUE))
-      if (other$size() > 0) {
-        variables$state$queue_update('S', other)
-      }
-      
-      # Update infectivity
-      variables$infectivity$queue_update(
-        variables$infectivity$get_values(
-          to_move
-        ) * parameters$drug_rel_c[[drug]],
-        to_move
-      )
-      
-      # Update drug
-      variables$drug$queue_update(drug, to_move)
-      variables$drug_time$queue_update(timestep, to_move)
-    }
   }
 }

--- a/R/processes.R
+++ b/R/processes.R
@@ -71,7 +71,7 @@ create_processes <- function(
   }
   
   # =====================================================
-  # Competing Hazard Outcomes (Infections and Recoveries)
+  # Competing Hazard Outcomes (infections and disease progression)
   # =====================================================
   
   infection_outcome <- CompetingOutcome$new(
@@ -83,9 +83,9 @@ create_processes <- function(
     size = parameters$human_population
   )
   
-  recovery_outcome <- CompetingOutcome$new(
+  progression_outcome <- CompetingOutcome$new(
     targeted_process = function(timestep, target){
-      recovery_outcome_process(timestep, target, variables, parameters, renderer)
+      progression_outcome_process(timestep, target, variables, parameters, renderer)
     },
     size = parameters$human_population
   )
@@ -119,14 +119,14 @@ create_processes <- function(
   
   processes <- c(
     processes,
-    progression_process = create_recovery_rates_process(
+    progression_process = create_progression_rates_process(
       variables,
-      recovery_outcome
+      progression_outcome
     ),
     
     # Resolve competing hazards of infection with disease progression
     hazard_resolution_process = CompetingHazard$new(
-      outcomes = list(infection_outcome, recovery_outcome),
+      outcomes = list(infection_outcome, progression_outcome),
       size = parameters$human_population
     )$resolve
   )

--- a/R/variables.R
+++ b/R/variables.R
@@ -192,15 +192,15 @@ create_variables <- function(parameters) {
   # Initialise the infectivity variable
   infectivity <- individual::DoubleVariable$new(infectivity_values)
 
-  # Set recovery rate for each individual
-  recovery_values <- rep(0, get_human_population(parameters, 0))
-  recovery_values[diseased] <- 1/parameters$dd
-  recovery_values[asymptomatic] <- 1/parameters$da
-  recovery_values[subpatent] <- 1/parameters$du
-  recovery_values[treated] <- 1/parameters$dt
+  # Set disease progression rates for each individual
+  progression_rate_values <- rep(0, get_human_population(parameters, 0))
+  progression_rate_values[diseased] <- 1/parameters$dd
+  progression_rate_values[asymptomatic] <- 1/parameters$da
+  progression_rate_values[subpatent] <- 1/parameters$du
+  progression_rate_values[treated] <- 1/parameters$dt
 
-  # Initialise the recovery rate variable
-  recovery_rates <- individual::DoubleVariable$new(recovery_values)
+  # Initialise the disease progression rate variable
+  progression_rates <- individual::DoubleVariable$new(progression_rate_values)
   
   drug <- individual::IntegerVariable$new(rep(0, size))
   drug_time <- individual::IntegerVariable$new(rep(-1, size))
@@ -231,7 +231,7 @@ create_variables <- function(parameters) {
     zeta = zeta,
     zeta_group = zeta_group,
     infectivity = infectivity,
-    recovery_rates = recovery_rates,
+    progression_rates = progression_rates,
     drug = drug,
     drug_time = drug_time,
     last_pev_timestep = last_pev_timestep,


### PR DESCRIPTION
I've created two new functions to standardise drug and resistance calculations across treatment and mass treatments:

calculate_successful_treatments
and
update_mass_drug_admin

calculate_successful_treatments handles the durg efficacy and antimalarial resistance, generating key outputs for each intervention type and returning a bitset of those treated, a vector of the drugs used to treat those individuals and a vector of treated delays for those individual if resistance (SPC) is switched on. This function is called during calculate_treated, create_mda_listeners and create_pmc_process.

update_mass_drug_admin calls update_infection twice, assigning D and LM-detectable A infections to Tr, while non-LM detectable A infections, U and Tr infections to S. Those assigned to S have 0 infectivity and 0 dt, while those who are assigned to Tr are assigned a fraction of their infectivity in the current timestep and dt from the parameter set or calculated using antimalarial resistance.