### PR TITLE
Update VectorControl_Bednets.Rmd

### DIFF
--- a/vignettes/VectorControl_Bednets.Rmd
+++ b/vignettes/VectorControl_Bednets.Rmd
@@ -90,10 +90,10 @@ bednetparams <- set_bednets(
   timesteps = bednetstimesteps,
   coverages = c(.5, .5),  # Each round is distributed to 50% of the population.
   retention = 5 * year, # Nets are kept on average 5 years
-  dn0 = matrix(c(.533, .533), nrow = 2, ncol = 1), # Matrix of death probabilities for each mosquito species over time
-  rn = matrix(c(.56, .56), nrow = 2, ncol = 1), # Matrix of repelling probabilities for each mosquito species over time
+  dn0 = matrix(c(.352, .352), nrow = 2, ncol = 1), # Matrix of death probabilities for each mosquito species over time
+  rn = matrix(c(.568, .568), nrow = 2, ncol = 1), # Matrix of repelling probabilities for each mosquito species over time
   rnm = matrix(c(.24, .24), nrow = 2, ncol = 1), # Matrix of minimum repelling probabilities for each mosquito species over time
-  gamman = rep(2.64 * 365, 2) # Vector of bed net half-lives for each distribution timestep
+  gamman = rep(2.226 * 365, 2) # Vector of bed net half-lives for each distribution timestep
 )
 
 output <- run_simulation(timesteps = sim_length, parameters = bednetparams)


### PR DESCRIPTION
The parameter values used for rn and dn0 were invalid (I think): we require s + d + r = 1, here we had d + r > 1. I've changed the values to represent pyrethroid-only ITNs, at 40% pyrethroid resistance

If I'm right about this, I'm surprised that this scenario runs without causing severe downstream issues (s<0 implies negative mosquito survival?). Could an error message be added somewhere, to prevent this parameter combination from being chosen?