### PR TITLE
Documentation: Fixed duplication & missing argument in death_rate() function documentation

### DIFF
--- a/R/mosquito_biology.R
+++ b/R/mosquito_biology.R
@@ -145,7 +145,8 @@ peak_season_offset <- function(parameters) {
 #' @param f the feeding rate for this species of mosquito
 #' @param W the mean probability that a mosquito feeds and survives
 #' @param Z the mean probability that a mosquito is repelled
-#' @param Z the mean probability that a mosquito is repelled
+#' @param species the index of the species to calculate the death rate for
+#' @param parameters the model parameters
 #' @noRd
 death_rate <- function(f, W, Z, species, parameters) {
   mum <- parameters$mum[[species]]


### PR DESCRIPTION
The roxygen documentation for the `death_rate()` function (mosquito_biology.R) contained a duplicated entry for the `Z` argument and no entries for the `species `or `parameters `arguments. I've:

1. removed the duplicated entry
2. added entries for the missing arguments that are consistent with the documentation for other functions in the mosquito_biology.R script. 