### PR TITLE
Update set_parameter_draw() to append draw to the parameter list

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -632,5 +632,6 @@ set_parameter_draw <- function(parameters, draw){
   for (name in names(parameter_draw)) {
     parameters[[name]] <- parameter_draw[[name]]
   }
+  parameters$parameter_draw <- draw
   return(parameters)
 }

--- a/tests/testthat/test-parameter_draws.R
+++ b/tests/testthat/test-parameter_draws.R
@@ -25,3 +25,19 @@ test_that("Draw overwrite works (vivax)", {
   p2 <- set_parameter_draw(p, 1000)
   expect_identical(p2[names(parameter_draws_pv[[1000]])], parameter_draws_pv[[1000]])
 })
+
+test_that("Parameter draw is appended to parameter list (falciparum)", {
+  p <- get_parameters()
+  p1 <- set_parameter_draw(p, 1000)
+  expect_identical(p$parameter_draw, NULL)
+  expect_identical(p1[names(parameter_draws_pf[[1000]])], parameter_draws_pf[[1000]])
+  expect_identical(p1$parameter_draw, 1000)
+})
+
+test_that("Parameter draw is appended to parameter list (vivax)", {
+  p <- get_parameters(parasite = "vivax")
+  p1 <- set_parameter_draw(p, 1000)
+  expect_identical(p$parameter_draw, NULL)
+  expect_identical(p1[names(parameter_draws_pv[[1000]])], parameter_draws_pv[[1000]])
+  expect_identical(p1$parameter_draw, 1000)
+})


### PR DESCRIPTION
It would be useful to be able to easily see whether:

a) a parameter list has been run through `set_parameter_draw()`
b) if so which parameter draw has been used

I have drafted a version of `set_parameter_draw()` which appends the draw provided to the parameter list as `$parameter_draw` and added some basic unit tests for both falciparum and vivax.