### PR TITLE
Feat/correlations repetitions

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -353,13 +353,15 @@ run_metapop_simulation <- function(
 #'
 #' @param timesteps the number of timesteps to run the simulation for
 #' @param repetitions n times to run the simulation
-#' @param overrides a named list of parameters to use instead of defaults
+#' @param parameters a named list of parameters to use
+#' @param correlations correlation parameters
 #' @param parallel execute runs in parallel
 #' @export
 run_simulation_with_repetitions <- function(
     timesteps,
     repetitions,
-    overrides = list(),
+    parameters,
+    correlations = NULL,
     parallel = FALSE
 ) {
   if (parallel) {
@@ -370,7 +372,11 @@ run_simulation_with_repetitions <- function(
   dfs <- fapply(
     seq(repetitions),
     function(repetition) {
-      df <- run_simulation(timesteps, overrides)
+      df <- run_simulation(
+        timesteps = timesteps,
+        parameters = parameters,
+        correlations = correlations
+      )
       df$repetition <- repetition
       df
     }

--- a/tests/testthat/test-simulation-e2e.R
+++ b/tests/testthat/test-simulation-e2e.R
@@ -49,3 +49,80 @@ test_that('run_metapop_simulation integrates two models correctly', {
   expect_equal(nrow(outputs[[1]]), 5)
   expect_equal(nrow(outputs[[2]]), 5)
 })
+
+test_that("run_simulation_with_repetitions() runs successfully without correlations specfied", {
+  
+  # Load the default parameters:
+  parameters <- get_parameters()
+  
+  # Specify a number of repetitions to run:
+  reps <- 2
+  
+  # Check the run_simulation_with_repetitions function runs without any correlation object specified:
+  testthat::expect_no_error(
+    run_simulation_with_repetitions(
+      timesteps = 10,
+      parameters = parameters, 
+      parallel = F,
+      repetitions = reps))
+  
+  # Check that the repetitions present in the output matches expectations:
+  expect_identical(object = unique(output$repetition), expected =  1:reps)
+  
+})
+
+test_that("run_simulation_with_repetitions() runs successfully with correlations specfied", {
+  
+  # Load the default model parameters:
+  parameters <- get_parameters()
+  
+  # Set some vaccination strategy
+  parameters <- set_mass_pev(
+    parameters,
+    profile = rtss_profile,
+    timesteps = 1,
+    coverages = .9,
+    min_wait = 0,
+    min_ages = 100,
+    max_ages = 1000,
+    booster_spacing = numeric(0),
+    booster_coverage = numeric(0),
+    booster_profile = NULL
+  )
+  
+  # Set some smc strategy
+  parameters <- set_drugs(parameters, list(SP_AQ_params))
+  parameters <- set_smc(
+    parameters,
+    drug = 1,
+    timesteps = 100,
+    coverages = .9,
+    min_age = 100,
+    max_age = 1000
+  )
+  
+  # Correlate the vaccination and smc targets
+  correlations <- get_correlation_parameters(parameters)
+  correlations$inter_intervention_rho('pev', 'smc', 1)
+  
+  # Correlate the rounds of smc
+  correlations$inter_round_rho('smc', 1)
+  
+  # Specify a number of repetitions to simulate:
+  reps <- 2
+  
+  # Run the simulation without any correlation object specified:
+  testthat::expect_no_error(
+    output <- run_simulation_with_repetitions(
+      timesteps = 10,
+      parameters = parameters, 
+      correlations = correlations,
+      parallel = F,
+      repetitions = reps
+    )
+  )
+  
+  # Check that the repetitions present in the output matches expectations:
+  expect_identical(object = unique(output$repetition), expected =  1:reps)
+  
+})


### PR DESCRIPTION
The `run_simulation_with_repetitions()` function doesn't currently allow users to iterated run simulations with correlations., which might be a useful thing to be able to do.

Here is an updated version of `run_simulation_with_repetitions()` that replaces the current overrides argument (used to input the parameters list) with parameters and correlations (default = NULL) arguments. I think this 
a) makes the arguments clearer
b) allows users to run repeated simulations with a single correlations object.

I have also added some basic tests to make sure the function runs with and without a correlations object.