### PR TITLE
Enable users to run_simulations_with_reptitions() with correlated interventions

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -353,13 +353,15 @@ run_metapop_simulation <- function(
 #'
 #' @param timesteps the number of timesteps to run the simulation for
 #' @param repetitions n times to run the simulation
-#' @param overrides a named list of parameters to use instead of defaults
+#' @param parameters a named list of parameters to use
+#' @param correlations correlation parameters
 #' @param parallel execute runs in parallel
 #' @export
 run_simulation_with_repetitions <- function(
     timesteps,
     repetitions,
-    overrides = list(),
+    parameters,
+    correlations = NULL,
     parallel = FALSE
 ) {
   if (parallel) {
@@ -370,7 +372,11 @@ run_simulation_with_repetitions <- function(
   dfs <- fapply(
     seq(repetitions),
     function(repetition) {
-      df <- run_simulation(timesteps, overrides)
+      df <- run_simulation(
+        timesteps = timesteps,
+        parameters = parameters,
+        correlations = correlations
+      )
       df$repetition <- repetition
       df
     }

--- a/R/model.R
+++ b/R/model.R
@@ -360,10 +360,13 @@ run_metapop_simulation <- function(
 run_simulation_with_repetitions <- function(
     timesteps,
     repetitions,
-    parameters,
+    parameters = NULL,
     correlations = NULL,
     parallel = FALSE
 ) {
+  if (is.null(parameters)) {
+    parameters <- get_parameters()
+  }
   if (parallel) {
     fapply <- parallel::mclapply
   } else {

--- a/man/run_simulation_with_repetitions.Rd
+++ b/man/run_simulation_with_repetitions.Rd
@@ -7,7 +7,8 @@
 run_simulation_with_repetitions(
   timesteps,
   repetitions,
-  overrides = list(),
+  parameters = NULL,
+  correlations = NULL,
   parallel = FALSE
 )
 }
@@ -16,7 +17,9 @@ run_simulation_with_repetitions(
 
 \item{repetitions}{n times to run the simulation}
 
-\item{overrides}{a named list of parameters to use instead of defaults}
+\item{parameters}{a named list of parameters to use}
+
+\item{correlations}{correlation parameters}
 
 \item{parallel}{execute runs in parallel}
 }

--- a/tests/testthat/test-simulation-e2e.R
+++ b/tests/testthat/test-simulation-e2e.R
@@ -49,3 +49,80 @@ test_that('run_metapop_simulation integrates two models correctly', {
   expect_equal(nrow(outputs[[1]]), 5)
   expect_equal(nrow(outputs[[2]]), 5)
 })
+
+test_that("run_simulation_with_repetitions() runs successfully without correlations specfied", {
+  
+  # Load the default parameters:
+  parameters <- get_parameters()
+  
+  # Specify a number of repetitions to run:
+  reps <- 2
+  
+  # Check the run_simulation_with_repetitions function runs without any correlation object specified:
+  testthat::expect_no_error(
+    simulation <- run_simulation_with_repetitions(
+      timesteps = 10,
+      parameters = parameters, 
+      parallel = F,
+      repetitions = reps))
+  
+  # Check that the repetitions present in the output matches expectations:
+  expect_identical(object = unique(simulation$repetition), expected =  1:reps)
+  
+})
+
+test_that("run_simulation_with_repetitions() runs successfully with correlations specfied", {
+  
+  # Load the default model parameters:
+  parameters <- get_parameters()
+  
+  # Set some vaccination strategy
+  parameters <- set_mass_pev(
+    parameters,
+    profile = rtss_profile,
+    timesteps = 1,
+    coverages = .9,
+    min_wait = 0,
+    min_ages = 100,
+    max_ages = 1000,
+    booster_spacing = numeric(0),
+    booster_coverage = numeric(0),
+    booster_profile = NULL
+  )
+  
+  # Set some smc strategy
+  parameters <- set_drugs(parameters, list(SP_AQ_params))
+  parameters <- set_smc(
+    parameters,
+    drug = 1,
+    timesteps = 100,
+    coverages = .9,
+    min_age = 100,
+    max_age = 1000
+  )
+  
+  # Correlate the vaccination and smc targets
+  correlations <- get_correlation_parameters(parameters)
+  correlations$inter_intervention_rho('pev', 'smc', 1)
+  
+  # Correlate the rounds of smc
+  correlations$inter_round_rho('smc', 1)
+  
+  # Specify a number of repetitions to simulate:
+  reps <- 2
+  
+  # Run the simulation without any correlation object specified:
+  testthat::expect_no_error(
+    output <- run_simulation_with_repetitions(
+      timesteps = 10,
+      parameters = parameters, 
+      correlations = correlations,
+      parallel = F,
+      repetitions = reps
+    )
+  )
+  
+  # Check that the repetitions present in the output matches expectations:
+  expect_identical(object = unique(output$repetition), expected =  1:reps)
+  
+})

--- a/tests/testthat/test-simulation-e2e.R
+++ b/tests/testthat/test-simulation-e2e.R
@@ -50,6 +50,11 @@ test_that('run_metapop_simulation integrates two models correctly', {
   expect_equal(nrow(outputs[[2]]), 5)
 })
 
+test_that('Simulation runs for a few timesteps', {
+  sim <- run_simulation_with_repetitions(timesteps = 10, repetitions = 2)
+  expect_equal(nrow(sim), 20)
+})
+
 test_that("run_simulation_with_repetitions() runs successfully without correlations specfied", {
   
   # Load the default parameters:

--- a/vignettes/Variation.Rmd
+++ b/vignettes/Variation.Rmd
@@ -177,15 +177,15 @@ simparams <- get_parameters() |>  set_equilibrium(init_EIR = 1)
 
 output_few_reps <- run_simulation_with_repetitions(
   timesteps = 365,
-  repetitions = 5,
-  overrides = simparams,
+  repetitions = 5, 
+  parameters = simparams,
   parallel=TRUE
 )
 
 output_many_reps <- run_simulation_with_repetitions(
   timesteps = 365,
   repetitions = 50,
-  overrides = simparams,
+  parameters = simparams,
   parallel=TRUE
 )
 


### PR DESCRIPTION
The existing version of `run_simulations_with_reptitions()` makes it difficult/impossible to run simulations with repetitions. This would be a useful feature, so I have:
 
- Replaced the `overrides()`  argument with `parameters` & `correlations`
- Set default value of `correlations` to `NULL`
- Replaced the `run_simulations()` argument assignment in the function to accept these two new arguments
- Written two unit tests that confirm that the function runs successfully with and without correlations input 