### PR TITLE
Amended set_parameter_draw() to load draw dataframes from package in function

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -627,9 +627,9 @@ parameterise_total_M <- function(parameters, total_M) {
 set_parameter_draw <- function(parameters, draw){
   
   if(parameters$parasite == "falciparum"){
-    parameter_draws <- parameter_draws_pf
+    parameter_draws <- malariasimulation::parameter_draws_pf
   } else if (parameters$parasite == "vivax"){
-    parameter_draws <- parameter_draws_pv
+    parameter_draws <- malariasimulation::parameter_draws_pv
   }
   
   if(draw > 1000 || draw < 1){


### PR DESCRIPTION
Currently, `set_parameter_draw()` will error if the following is run without first calling `library(malariasimulation)`:

```
p <- malariasimulation::get_parameters()
o <- malariasimulation::set_parameter_draw()
```

Ideally, we would be able to run this function like this as, for example, it is useful in secondary packages that build around `malariasimulation`.

Within `set_parameter_draw()`, I've added `malariasimulation::` in front of the `parameter_draws_pf  `and `parameter_draws_pv `objects which allows the above to work without first loading `malariasimulation` using `library()`.

I haven't currently added any unit tests for this change as I'm not sure how to test this functionality within the package, but open to suggestions! I have however installed the package from the branch and confirmed that it works as follows:

```
devtools::install_github('mrc-ide/malariasimulation@fix/parameter_draws')
p <- malariasimulation::get_parameters()
o <- malariasimulation:::set_parameter_draw(parameters = p, draw = 1)
```