### PR TITLE
Implement non-malarial fever feature

### DIFF
--- a/R/human_infection.R
+++ b/R/human_infection.R
@@ -284,6 +284,7 @@ pev_efficacy <- function(
 #' and treated malaria; and resulting boosts in immunity
 #' @param timestep current timestep
 #' @param infected_humans bitset of infected humans
+#' @param nmf bitset of individuals with non-malarial fever
 #' @param variables a list of all of the model variables
 #' @param renderer model render object
 #' @param parameters model parameters
@@ -292,10 +293,14 @@ pev_efficacy <- function(
 falciparum_infection_outcome_process <- function(
     timestep,
     infected_humans,
+    nmf,
     variables,
     renderer,
     parameters){
-  
+
+  renderer$set_default('n_treated_nmf', 0)
+
+
   if (infected_humans$size() > 0) {
     
     renderer$render('n_infections', infected_humans$size(), timestep)
@@ -332,10 +337,14 @@ falciparum_infection_outcome_process <- function(
       renderer,
       timestep
     )
-    
+
+    nmf$set_difference(clinical)
+    nmf_detectable <- nmf$copy()$and(variables$state$get_index_of(c('D','A','U')))
+
     treated <- calculate_treated(
       variables,
       clinical,
+      nmf_detectable,
       parameters,
       timestep,
       renderer
@@ -698,6 +707,7 @@ update_severe_disease <- function(
 #' Sample treated humans from the clinically infected
 #' @param variables a list of all of the model variables
 #' @param clinical_infections a bitset of clinically infected humans
+#' @param nmf_detectable a bitset of nmf individuals with detectable malaria
 #' @param parameters model parameters
 #' @param timestep the current timestep
 #' @param renderer simulation renderer
@@ -705,12 +715,13 @@ update_severe_disease <- function(
 calculate_treated <- function(
     variables,
     clinical_infections,
+    nmf_detectable,
     parameters,
     timestep,
     renderer
 ) {
-  
-  if(clinical_infections$size() == 0) {
+
+  if(clinical_infections$size() == 0 && nmf_detectable$size() == 0) {
     return(individual::Bitset$new(parameters$human_population))
   }
   
@@ -722,9 +733,12 @@ calculate_treated <- function(
   }
   
   renderer$render('ft', ft, timestep)
-  seek_treatment <- sample_bitset(clinical_infections, ft)
-  n_treat <- seek_treatment$size()
-  renderer$render('n_treated', n_treat, timestep)
+  seek_treat_clin <- sample_bitset(clinical_infections, ft)
+  seek_treat_nmf <- sample_bitset(nmf_detectable, ft)
+  renderer$render('n_treated', seek_treat_clin$size(), timestep)
+  renderer$render('n_treated_nmf', seek_treat_nmf$size(), timestep)
+  treaters <- seek_treat_clin$copy()$or(seek_treat_nmf)
+  n_treat <- treaters$size()
   
   drugs <- as.numeric(parameters$clinical_treatment_drugs[
     sample.int(
@@ -737,7 +751,7 @@ calculate_treated <- function(
   
   successfully_treated <- calculate_successful_treatments(
     parameters,
-    seek_treatment,
+    treaters,
     drugs,
     timestep,
     renderer,

--- a/R/model.R
+++ b/R/model.R
@@ -15,6 +15,8 @@
 #'  the whole population)
 #'  * n_bitten: number of humans bitten by an infectious mosquito
 #'  * n_treated: number of humans treated for clinical or severe malaria this timestep
+#'  * n_nmf: number of non-malarial fevers in the population
+#'  * n_treated_nmf: number of individuals treated due to non-malarial fever
 #'  * n_infections: number of humans who get an asymptomatic, clinical or severe malaria this timestep
 #'  * natural_deaths: number of humans who die from aging
 #'  * S_count: number of humans who are Susceptible

--- a/R/non_malarial_fever.R
+++ b/R/non_malarial_fever.R
@@ -1,0 +1,49 @@
+#' @title Parameterise non-malarial fevers
+#' @description
+#' Set age specific daily rates of non-malarial fever.
+#'
+#' @param parameters model parameters
+#' @param ages vector of upper age bounds (in timesteps) for each fever rate
+#' @param rates vector of rates of non-malarial fever per day
+#' @return updated parameter list
+#' @export
+set_nmf <- function(parameters, ages, rates){
+  stopifnot(length(ages) == length(rates))
+  stopifnot(all(rates >= 0) & all(rates <= 1))
+  stopifnot(all(diff(c(0, ages)) > 0))
+  parameters$nmf_ages <- ages
+  parameters$nmf_rates <- rates
+  parameters
+}
+
+#' @title Non malarial fever process
+#' @description
+#' Samples individuals experiencing non-malarial fever.
+#'
+#' @param variables list of model variables
+#' @param parameters model parameters
+#' @param renderer model renderer
+#' @param nmf bitset used to store individuals with fever
+#' @return a function called at each timestep
+#' @noRd
+create_nmf_process <- function(variables, parameters, renderer, nmf){
+  renderer$set_default('n_nmf', 0)
+  function(timestep){
+    nmf$clear()
+    pop <- get_human_population(parameters, timestep)
+    if(length(parameters$nmf_rates) == 0 || pop == 0){
+      return()
+    }
+    age <- get_age(variables$birth$get_values(), timestep)
+    groups <- .bincode(age, c(0, parameters$nmf_ages))
+    rates <- rep(0, pop)
+    in_range <- !is.na(groups)
+    rates[in_range] <- parameters$nmf_rates[groups[in_range]]
+    nmf$insert(bernoulli_multi_p(rates))
+    renderer$render('n_nmf', nmf$size(), timestep)
+    if(nmf$size() > 0){
+      current <- variables$nmf_count$get_values(nmf)
+      variables$nmf_count$queue_update(current + 1L, nmf)
+    }
+  }
+}

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -322,7 +322,14 @@
 #' and PCR prevalence; default = -0.968
 #' * rdt_coeff - the coefficient for the log logit relationship betweeen rdt
 #' and PCR prevalence; default = 1.186
-#' 
+#'
+#' Non-malarial fever parameters:
+#'
+#' * nmf_rates - vector of rates of non-malarial fever per day for each
+#'   age group; default = numeric(0)
+#' * nmf_ages - upper bounds of the corresponding age groups (in timesteps);
+#'   default = numeric(0)
+#'
 #' miscellaneous:
 #'
 #' * mosquito_limit - the maximum number of mosquitoes to allow for in the
@@ -506,6 +513,8 @@ get_parameters <- function(overrides = list(), parasite = "falciparum") {
       # mixing
       rdt_intercept = -0.968,
       rdt_coeff = 1.186,
+      nmf_rates = numeric(0),
+      nmf_ages = numeric(0),
       # misc
       mosquito_limit   = 100 * 1000,
       individual_mosquitoes = FALSE,

--- a/R/processes.R
+++ b/R/processes.R
@@ -35,7 +35,9 @@ create_processes <- function(
     mixing_fn = NULL,
     mixing_index = 1
 ) {
-  
+
+  nmf <- individual::Bitset$new(parameters$human_population)
+
   # ========
   # Immunity
   # ========
@@ -94,11 +96,16 @@ create_processes <- function(
   # Competing Hazard Outcomes (infections and disease progression)
   # =====================================================
   
-  if(parameters$parasite == "falciparum"){
+  if(parameters$parasite == "falciparum"){ 
     infection_outcome <- CompetingOutcome$new(
       targeted_process = function(timestep, target){
-        falciparum_infection_outcome_process(timestep, target, 
-                                  variables, renderer, parameters
+        falciparum_infection_outcome_process(
+          timestep,
+          target,
+          nmf,
+          variables,
+          renderer,
+          parameters
         )
       },
       size = parameters$human_population
@@ -334,6 +341,16 @@ create_processes <- function(
       progress_bar_process = create_progress_process(timesteps)
     )
   }
+
+  processes <- c(
+    processes,
+    nmf_process = create_nmf_process(
+      variables,
+      parameters,
+      renderer,
+      nmf
+    )
+  )
 
   # ======================
   # Mortality step

--- a/R/render.R
+++ b/R/render.R
@@ -253,6 +253,8 @@ populate_incidence_rendering_columns <- function(renderer, parameters){
   # infections must render in all simulations 
   renderer$set_default('n_bitten', 0)
   renderer$set_default('n_infections', 0)
+  renderer$set_default('n_nmf', 0)
+  renderer$set_default('n_treated_nmf', 0)
   
   # treatment associated only renders when drugs are used
   if(sum(unlist(parameters$clinical_treatment_coverages))>0){

--- a/R/variables.R
+++ b/R/variables.R
@@ -37,6 +37,7 @@
 #' * drug_time - The timestep of the last drug
 #' * ls_drug - The last prescribed liver-stage drug
 #' * ls_drug_time - The timestep of the last liver-stage drug
+#' * nmf_count - Cumulative number of non-malarial fevers experienced
 #'
 #' Antimalarial resistance variables are:
 #' * dt - the delay for humans to move from state Tr to state S
@@ -299,6 +300,8 @@ create_variables <- function(parameters) {
 
   tbv_vaccinated <- individual::DoubleVariable$new(rep(-1, size))
 
+  nmf_count <- individual::IntegerVariable$new(rep(0L, size))
+
   # Init vector controls
   net_time <- individual::IntegerVariable$new(rep(-1, size))
   spray_time <- individual::IntegerVariable$new(rep(-1, size))
@@ -319,6 +322,7 @@ create_variables <- function(parameters) {
     last_eff_pev_timestep = last_eff_pev_timestep,
     pev_profile = pev_profile,
     tbv_vaccinated = tbv_vaccinated,
+    nmf_count = nmf_count,
     net_time = net_time,
     spray_time = spray_time
   )

--- a/tests/testthat/test-infection-integration.R
+++ b/tests/testthat/test-infection-integration.R
@@ -22,9 +22,10 @@ test_that('simulate_infection integrates different types of infection and schedu
   infection_mock <- mockery::mock(infected)
   n_bites_per_person <- NULL
   
+  nmf <- individual::Bitset$new(population)
   infection_outcome <- CompetingOutcome$new(
     targeted_process = function(timestep, target, args){
-      falciparum_infection_outcome_process(timestep, target, variables, renderer, parameters)
+      falciparum_infection_outcome_process(timestep, target, nmf, variables, renderer, parameters)
     },
     size = parameters$human_population
   )
@@ -110,6 +111,7 @@ test_that('simulate_infection integrates different types of infection and schedu
   falciparum_infection_outcome_process(
     timestep,
     infected,
+    nmf,
     variables,
     renderer,
     parameters)
@@ -219,9 +221,10 @@ test_that('calculate_infections works various combinations of drug and vaccinati
   bitten_humans <- individual::Bitset$new(4)$insert(c(1, 2, 3, 4))
   n_bites_per_person <- numeric(0)
   
+  nmf <- individual::Bitset$new(4)
   infection_outcome <- CompetingOutcome$new(
     targeted_process = function(timestep, target){
-      falciparum_infection_outcome_process(timestep, target, variables, renderer, parameters)
+      falciparum_infection_outcome_process(timestep, target, nmf, variables, renderer, parameters)
     },
     size = 4
   )
@@ -347,6 +350,7 @@ test_that('calculate_treated correctly samples treated and updates the drug stat
   calculate_treated(
     variables,
     clinical_infections,
+    individual::Bitset$new(4),
     parameters,
     timestep,
     mock_render(timestep)
@@ -436,6 +440,7 @@ test_that('calculate_treated correctly samples treated and updates the drug stat
   calculate_treated(
     variables,
     clinical_infections,
+    individual::Bitset$new(20),
     parameters,
     timestep,
     renderer
@@ -556,6 +561,7 @@ test_that('calculate_treated correctly samples treated and updates the drug stat
   calculate_treated(
     variables,
     clinical_infections,
+    individual::Bitset$new(20),
     parameters,
     timestep,
     mock_render(timestep)
@@ -700,9 +706,10 @@ test_that('prophylaxis is considered for medicated humans', {
   m <- mockery::mock(seq(3))
   mockery::stub(calculate_falciparum_infections, 'bernoulli_multi_p', m)
   
+  nmf <- individual::Bitset$new(4)
   infection_outcome <- CompetingOutcome$new(
     targeted_process = function(timestep, target){
-      falciparum_infection_outcome_process(timestep, target, variables, renderer, parameters)
+      falciparum_infection_outcome_process(timestep, target, nmf, variables, renderer, parameters)
     },
     size = 4
   )
@@ -905,6 +912,7 @@ test_that('calculate_treated returns empty Bitset when there is no clinical trea
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
+                               nmf_detectable = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -941,6 +949,7 @@ test_that('calculate_treated returns empty Bitset when the clinically_infected i
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
+                               nmf_detectable = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -965,6 +974,7 @@ test_that('calculate_treated() returns an empty Bitset when the parameter list c
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
+                               nmf_detectable = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -1019,6 +1029,7 @@ test_that('Number of treatment failures matches number of individuals treated wh
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
+                               nmf_detectable = individual::Bitset$new(100),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -1058,6 +1069,7 @@ test_that('calculate_treated() successfully adds additional resistance columns t
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
+                               nmf_detectable = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)

--- a/tests/testthat/test-nmf.R
+++ b/tests/testthat/test-nmf.R
@@ -1,0 +1,47 @@
+test_that('set_nmf sets rates correctly', {
+  p <- get_parameters()
+  p <- set_nmf(p, ages = c(365, 10*365), rates = c(0.1, 0.05))
+  expect_equal(p$nmf_ages, c(365, 10*365))
+  expect_equal(p$nmf_rates, c(0.1, 0.05))
+})
+
+test_that('set_nmf validates inputs', {
+  p <- get_parameters()
+  expect_error(set_nmf(p, ages = c(1,1), rates = c(0.5)), 'length')
+  expect_error(set_nmf(p, ages = c(10,5), rates = c(0.1,0.1)), 'diff')
+  expect_error(set_nmf(p, ages = 1, rates = -0.1), 'all\(rates >= 0\)')
+})
+
+
+test_that('non malarial fevers treat individuals', {
+  p <- get_parameters(list(human_population = 3))
+  p <- set_drugs(p, list(SP_AQ_params))
+  p <- set_clinical_treatment(p, drug = 1, timesteps = 0, coverages = 1)
+  p <- set_nmf(p, ages = c(1000), rates = c(1))
+
+  vars <- create_variables(p)
+  renderer <- individual::Render$new(1)
+  nmf <- individual::Bitset$new(p$human_population)
+
+  local_mocked_bindings(
+    rdt_detectable = function(variables, parameters, timestep) 1
+  )
+
+  nmf_process <- create_nmf_process(vars, p, renderer, nmf)
+  nmf_process(1)
+
+  falciparum_infection_outcome_process(
+    1,
+    individual::Bitset$new(p$human_population),
+    nmf,
+    vars,
+    renderer,
+    p
+  )
+
+  df <- renderer$to_dataframe()
+  expect_equal(df$n_nmf[[1]], 3)
+  expect_equal(df$n_treated_nmf[[1]], 3)
+  expect_equal(vars$state$get_values(), rep('Tr', 3))
+  expect_equal(vars$nmf_count$get_values(), rep(1L,3))
+})

--- a/tests/testthat/test-pev.R
+++ b/tests/testthat/test-pev.R
@@ -150,9 +150,10 @@ test_that('Infection considers pev efficacy', {
     rep(.2, 4)
   )
 
+  nmf <- individual::Bitset$new(4)
   infection_outcome <- CompetingOutcome$new(
     targeted_process = function(timestep, target){
-      falciparum_infection_outcome_process(timestep, target, variables, renderer, parameters)
+      falciparum_infection_outcome_process(timestep, target, nmf, variables, renderer, parameters)
     },
     size = 4
   )


### PR DESCRIPTION
## Summary
- add helper and process for non-malarial fevers
- track NMF counts via new `nmf_count` variable
- expose `set_nmf()` for age-specific fever rates
- integrate process into simulation
- test new parameterisation and process

## Testing
- `devtools::document()` *(fails: R not installed)*
- `devtools::test()` *(fails: R not installed)*
- `devtools::check()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68650bd69cbc83268dc97207e022fc5a