### PR TITLE
nmf-render-tidy

### DIFF
--- a/R/human_infection.R
+++ b/R/human_infection.R
@@ -298,10 +298,7 @@ falciparum_infection_outcome_process <- function(
     renderer,
     parameters){
 
-  renderer$set_default('n_treated_nmf', 0)
-
-
-  if (infected_humans$size() > 0) {
+  if (infected_humans$size() > 0 || nmf$size() > 0) {
     
     renderer$render('n_infections', infected_humans$size(), timestep)
     incidence_renderer(
@@ -340,7 +337,7 @@ falciparum_infection_outcome_process <- function(
 
     nmf$set_difference(clinical)
     nmf_detectable <- nmf$copy()$and(variables$state$get_index_of(c('D','A','U')))
-    renderer$render('nmf_detectable', nmf_detectable$size(), timestep)
+    renderer$render('n_nmf_malaria_detectable', nmf_detectable$size(), timestep)
     
     treated <- calculate_treated(
       variables,

--- a/R/model.R
+++ b/R/model.R
@@ -17,6 +17,7 @@
 #'  * n_treated: number of humans treated for clinical or severe malaria this timestep
 #'  * n_nmf: number of non-malarial fevers in the population
 #'  * n_treated_nmf: number of individuals treated due to non-malarial fever
+#'  * n_nmf_malaria_detectable: number of non-malarial fever cases with detectable malaria
 #'  * n_infections: number of humans who get an asymptomatic, clinical or severe malaria this timestep
 #'  * natural_deaths: number of humans who die from aging
 #'  * S_count: number of humans who are Susceptible

--- a/R/render.R
+++ b/R/render.R
@@ -255,6 +255,7 @@ populate_incidence_rendering_columns <- function(renderer, parameters){
   renderer$set_default('n_infections', 0)
   renderer$set_default('n_nmf', 0)
   renderer$set_default('n_treated_nmf', 0)
+  renderer$set_default('n_nmf_malaria_detectable', 0)
   
   # treatment associated only renders when drugs are used
   if(sum(unlist(parameters$clinical_treatment_coverages))>0){

--- a/tests/testthat/test-nmf.R
+++ b/tests/testthat/test-nmf.R
@@ -41,6 +41,7 @@ test_that('non malarial fevers treat individuals', {
 
   df <- renderer$to_dataframe()
   expect_equal(df$n_nmf[[1]], 3)
+  expect_equal(df$n_nmf_malaria_detectable[[1]], 3)
   expect_equal(df$n_treated_nmf[[1]], 3)
   expect_equal(vars$state$get_values(), rep('Tr', 3))
   expect_equal(vars$nmf_count$get_values(), rep(1L,3))


### PR DESCRIPTION
## Summary
- track NMF fevers detected with malaria via `n_nmf_malaria_detectable`
- initialise new render column once when populating renderer
- process NMF outcomes if fevers occur even without infections
- test detectable NMF rendering

## Testing
- `R -q -e "devtools::document(); devtools::test();"` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68652933aa3c8326a0097f618b6ef807