### PR TITLE
nmf-test-align

### DIFF
--- a/tests/testthat/test-infection-integration.R
+++ b/tests/testthat/test-infection-integration.R
@@ -912,7 +912,7 @@ test_that('calculate_treated returns empty Bitset when there is no clinical trea
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(20),
+                               nmf = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -949,7 +949,7 @@ test_that('calculate_treated returns empty Bitset when the clinically_infected i
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(20),
+                               nmf = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -974,7 +974,7 @@ test_that('calculate_treated() returns an empty Bitset when the parameter list c
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(20),
+                               nmf = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -1029,7 +1029,7 @@ test_that('Number of treatment failures matches number of individuals treated wh
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(100),
+                               nmf = individual::Bitset$new(100),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -1069,7 +1069,7 @@ test_that('calculate_treated() successfully adds additional resistance columns t
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(20),
+                               nmf = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)

--- a/tests/testthat/test-vivax.R
+++ b/tests/testthat/test-vivax.R
@@ -287,10 +287,12 @@ test_that('relapses are recognised with division between bite infections and rel
 
   renderer <- mock_render(1)
   infected_humans <- individual::Bitset$new(4)$insert(c(1, 2, 3, 4))
-  
+  nmf <- individual::Bitset$new(4)
+
   vivax_infection_outcome_process(
     timestep = timestep,
     infected_humans,
+    nmf,
     variables,
     renderer,
     parameters,


### PR DESCRIPTION
## Summary
- fix test-vivax to provide nmf bitset
- update infection integration tests with nmf argument

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68668c0f0cbc832687f94c3d8533f8b4