### PR TITLE
nmf-test-align

### DIFF
--- a/tests/testthat/test-infection-integration.R
+++ b/tests/testthat/test-infection-integration.R
@@ -96,6 +96,7 @@ test_that('simulate_infection integrates different types of infection and schedu
   treated <- individual::Bitset$new(population)$insert(3)
   treated_mock <- mockery::mock(treated)
   schedule_mock <- mockery::mock()
+  nmf <- individual::Bitset$new(population)
 
   to_D <- treated$not(FALSE)$and(clinical)
   to_A <- infected$and(clinical$not(FALSE))
@@ -912,7 +913,7 @@ test_that('calculate_treated returns empty Bitset when there is no clinical trea
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(20),
+                               nmf = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -949,7 +950,7 @@ test_that('calculate_treated returns empty Bitset when the clinically_infected i
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(20),
+                               nmf = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -974,7 +975,7 @@ test_that('calculate_treated() returns an empty Bitset when the parameter list c
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(20),
+                               nmf = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -1029,7 +1030,7 @@ test_that('Number of treatment failures matches number of individuals treated wh
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(100),
+                               nmf = individual::Bitset$new(100),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)
@@ -1069,7 +1070,7 @@ test_that('calculate_treated() successfully adds additional resistance columns t
   
   treated <- calculate_treated(variables = variables,
                                clinical_infections = clinical_infections,
-                               nmf_detectable = individual::Bitset$new(20),
+                               nmf = individual::Bitset$new(20),
                                parameters = parameters,
                                timestep = timestep,
                                renderer = renderer)

--- a/tests/testthat/test-vivax.R
+++ b/tests/testthat/test-vivax.R
@@ -287,10 +287,12 @@ test_that('relapses are recognised with division between bite infections and rel
 
   renderer <- mock_render(1)
   infected_humans <- individual::Bitset$new(4)$insert(c(1, 2, 3, 4))
-  
+  nmf <- individual::Bitset$new(4)
+
   vivax_infection_outcome_process(
     timestep = timestep,
     infected_humans,
+    nmf,
     variables,
     renderer,
     parameters,


### PR DESCRIPTION
## Summary
- fix second infection-integration test by defining a `nmf` bitset
- ensure new `nmf` argument used in tests calling infection outcome processes

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68668c0f0cbc832687f94c3d8533f8b4