### PR TITLE
Adding entries for ivm and iva to run_simulation documentation

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -24,6 +24,8 @@
 #'  * Tr_count: number of detectable infections being treated in humans
 #'  * ica_mean: the mean acquired immunity to clinical infection over the population of humans
 #'  * icm_mean: the mean maternal immunity to clinical infection over the population of humans
+#'  * iva_mean: the mean acquired immunity to severe infection over the population of humans
+#'  * ivm_mean: the mean maternal immunity to severe infection over the population of humans
 #'  * ib_mean: the mean blood immunity to all infection over the population of humans
 #'  * id_mean: the mean immunity from detection through microscopy over the population of humans
 #'  * n: number of humans between an inclusive age range at this timestep. This

--- a/man/run_simulation.Rd
+++ b/man/run_simulation.Rd
@@ -40,6 +40,8 @@ the whole population)
 \item Tr_count: number of detectable infections being treated in humans
 \item ica_mean: the mean acquired immunity to clinical infection over the population of humans
 \item icm_mean: the mean maternal immunity to clinical infection over the population of humans
+\item iva_mean: the mean acquired immunity to severe infection over the population of humans
+\item ivm_mean: the mean maternal immunity to severe infection over the population of humans
 \item ib_mean: the mean blood immunity to all infection over the population of humans
 \item id_mean: the mean immunity from detection through microscopy over the population of humans
 \item n: number of humans between an inclusive age range at this timestep. This


### PR DESCRIPTION
As outlined in issue #381,  the `run_simulation()` documentation was missing entries for `ivm` and `iva` outputs.

I've made added entries to the roxygen2 docs and updated the helper file.